### PR TITLE
Include attributes starting with `urlPreview` when merging cards

### DIFF
--- a/src/components/dialogs/MultipleSelectedActions.vue
+++ b/src/components/dialogs/MultipleSelectedActions.vue
@@ -337,8 +337,15 @@ export default {
     mergeSelectedCards () {
       let name = ''
       const cards = this.cardsSortedByY()
+      const urlPreview = {}
       cards.forEach(card => {
         name = `${name}\n\n${card.name.trim()}`
+
+        Object.keys(card).forEach(key => {
+          if (key.startsWith('urlPreview') && card[key] && !urlPreview[key]) {
+            urlPreview[key] = card[key]
+          }
+        })
       })
       name = name.trim()
       let newNames = []
@@ -375,7 +382,8 @@ export default {
           id: nanoid(),
           name: newName,
           x: position.x,
-          y: position.y
+          y: position.y,
+          ...urlPreview
         }
         newCards.push(newCard)
       })

--- a/src/store/currentCards.js
+++ b/src/store/currentCards.js
@@ -237,7 +237,12 @@ const currentCards = {
           userId: context.rootState.currentUser.id,
           backgroundColor: card.backgroundColor,
           shouldUpdateUrlPreview: true,
-          urlPreviewIsVisible: true
+          urlPreviewIsVisible: true,
+          urlPreviewDescription: card.urlPreviewDescription,
+          urlPreviewFavicon: card.urlPreviewFavicon,
+          urlPreviewImage: card.urlPreviewImage,
+          urlPreviewTitle: card.urlPreviewTitle,
+          urlPreviewUrl: card.urlPreviewUrl
         }
       })
       newCards.forEach(card => {


### PR DESCRIPTION
This is supposed to fix https://club.kinopio.club/t/merging-url-only-card-with-text-card-removes-url/1170/2


https://github.com/kinopio-club/kinopio-client/assets/10014895/2fff9702-cd16-463d-b429-247fe0e66844

