### PR TITLE
Fixes issue with document.title in WindowHistoryHandler

### DIFF
--- a/src/components/SpaceDetailsInfo.vue
+++ b/src/components/SpaceDetailsInfo.vue
@@ -195,6 +195,7 @@ export default {
         this.textareaSize()
         this.$store.dispatch('currentSpace/updateSpace', { name: newName })
         this.updateLocalSpaces()
+        this.$store.commit('triggerUpdateWindowTitle')
       }
     },
     currentSpace () { return this.$store.state.currentSpace },

--- a/src/components/WindowHistoryHandler.vue
+++ b/src/components/WindowHistoryHandler.vue
@@ -11,6 +11,8 @@ export default {
       if (mutation.type === 'triggerUpdateWindowHistory') {
         await this.updateWindowHistory(mutation.payload)
         this.updateWindowTitle()
+      } else if (mutation.type === 'triggerUpdateWindowTitle') {
+        this.updateWindowTitle()
       }
     })
   },

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -578,6 +578,7 @@ const store = createStore({
     triggerAddSpaceIsVisible: () => {},
     triggerOfflineIsVisible: () => {},
     triggerAppsAndExtensionsIsVisible: () => {},
+    triggerUpdateWindowTitle: () => {},
 
     // Used by extensions only
 


### PR DESCRIPTION
I tried this in Firefox and Chrome, and it seems to be resolving the initial issue: https://club.kinopio.club/t/tab-title-link-update-dont-update-at-the-same-time-browser-history-gets-weird/1209

The key insight is, that `document.title = x` has to get called after `$router.push` to get this to work correctly.
I also had to remove the watcher on `currentSpaceName` because it wouldn't work otherwise. I am not sure if this has other implications, but in my tests everything seemed to work fine. 

I ran through the same sequence of spaces before and after the fix:

**Before**
<img width="1040" alt="Bildschirmfoto 2024-01-17 um 10 55 27" src="https://github.com/kinopio-club/kinopio-client/assets/10014895/09a6ba96-8330-4134-a80d-c32aa16432bd">

**After**
<img width="1040" alt="Bildschirmfoto 2024-01-17 um 10 54 21" src="https://github.com/kinopio-club/kinopio-client/assets/10014895/cec2f61f-b914-44d3-bef5-bba351f3a096">