### PR TITLE
fix touch selection on my laptop

### DIFF
--- a/src/components/KeyboardShortcutsHandler.vue
+++ b/src/components/KeyboardShortcutsHandler.vue
@@ -299,7 +299,7 @@ const handleScrollEvents = (event) => {
 }
 // on native right-click context menu
 const handleContextMenuEvents = (event) => {
-  if (disableContextMenu) {
+  if (disableContextMenu || store.state.currentUserIsPaintingLocked) {
     disableContextMenu = false
     event.preventDefault()
   }


### PR DESCRIPTION
not sure what other devices this applies to, but on my laptop screen when i longpress to start a selection i have to start moving very quickly in the gap between when painting starts and when the context menu opens. this fixes the issue.