### PR TITLE
make pasting more robust, especially on firefox

### DIFF
--- a/src/components/KeyboardShortcutsHandler.vue
+++ b/src/components/KeyboardShortcutsHandler.vue
@@ -626,8 +626,11 @@ const getClipboardData = async () => {
       }
       return data
     }
-    notifyPasted(position)
-    return utils.dataFromClipboard()
+    const data = await utils.dataFromClipboard()
+    if (data.text || data.file) {
+      notifyPasted(position)
+      return data
+    }
   } catch (error) {
     console.error('🚑 getClipboardData', error)
     store.commit('addNotificationWithPosition', { message: `Could not paste`, position, type: 'danger', layer: 'app', icon: 'cut' })

--- a/src/utils.js
+++ b/src/utils.js
@@ -2217,8 +2217,13 @@ export default {
         const extension = imageType.substring(index)
         file = new File([blob], `pasted.${extension}`)
       } else {
-        text = await navigator.clipboard.readText()
+        if (item.types.includes('text/plain')) {
+          text = await (await item.getType('text/plain')).text()
+        }
       }
+    }
+    if (text == null && file == null) {
+      text = await navigator.clipboard.readText()
     }
     return { text, file }
   },

--- a/src/utils.js
+++ b/src/utils.js
@@ -2218,7 +2218,8 @@ export default {
         file = new File([blob], `pasted.${extension}`)
       } else {
         if (item.types.includes('text/plain')) {
-          text = await (await item.getType('text/plain')).text()
+          const blob = await item.getType('text/plain')
+          text = await blob.text()
         }
       }
     }


### PR DESCRIPTION
This gets rid of a permission prompt when pasting text in Firefox and ensures the "Pasted" message doesn't show up when there was an error inside `utils.dataFromClipboard`