### PR TITLE
perf: svg per connection

### DIFF
--- a/src/collisionDetection.js
+++ b/src/collisionDetection.js
@@ -89,7 +89,6 @@ export default {
 
   checkPointsInsidePaths (points, paths, svg) {
     // Convert points to SVG points
-    // const svg = document.querySelector('svg.connections')
     const svgPoints = Array.from(points).map(point => {
       let svgPoint = svg.createSVGPoint()
       svgPoint.x = point.x

--- a/src/components/Box.vue
+++ b/src/components/Box.vue
@@ -143,7 +143,7 @@ const infoClasses = computed(() => {
 // edge snapping
 
 const otherBoxes = computed(() => {
-  const boxes = store.getters['currentBoxes/all']
+  const boxes = store.getters['currentBoxes/isSelectableInViewport']
   return boxes.filter(box => box.id !== props.box.id)
 })
 const snapGuideStyles = computed(() => {

--- a/src/components/Box.vue
+++ b/src/components/Box.vue
@@ -643,6 +643,7 @@ const endBoxInfoInteractionTouch = (event) => {
   .box-info(
     v-if="state.isVisibleInViewport"
     :data-box-id="box.id"
+    :data-is-visible-in-viewport="state.isVisibleInViewport"
     :style="labelStyles"
     :class="infoClasses"
     tabindex="0"

--- a/src/components/Connection.vue
+++ b/src/components/Connection.vue
@@ -75,9 +75,7 @@ const updatePathWhileDragging = (value) => {
 }
 const normalizedConnectionPathRect = () => {
   const path = state.pathWhileDragging || props.connection.path
-  const pathStart = utils.startCoordsFromConnectionPath(path)
-  const pathEndRelative = utils.endCoordsFromConnectionPath(path)
-  const rect = utils.rectFromConnectionPathCoords(pathStart, pathEndRelative)
+  const rect = utils.rectFromConnectionPath(path)
   return rect
 }
 const connectionStyles = computed(() => {

--- a/src/components/Connection.vue
+++ b/src/components/Connection.vue
@@ -2,9 +2,7 @@
 import { reactive, computed, onMounted, onBeforeUnmount, onUnmounted, defineProps, defineEmits, watch, ref, nextTick } from 'vue'
 import { useStore } from 'vuex'
 
-import ConnectionLabel from '@/components/ConnectionLabel.vue'
 import utils from '@/utils.js'
-
 const store = useStore()
 
 let animationTimer, isMultiTouch, startCursor, currentCursor
@@ -532,8 +530,6 @@ svg.connection(
     :data-relative-path="relativePath"
   )
     animateMotion(dur="3s" repeatCount="indefinite" :path="relativePath" rotate="auto")
-
-  ConnectionLabel(:connection="connection")
 </template>
 
 <style lang="stylus">

--- a/src/components/Connection.vue
+++ b/src/components/Connection.vue
@@ -40,7 +40,6 @@ onMounted(() => {
   })
   initViewportObserver()
 })
-
 onBeforeUnmount(() => {
   removeViewportObserver()
 })

--- a/src/components/Connection.vue
+++ b/src/components/Connection.vue
@@ -52,6 +52,7 @@ watch(() => props.connection.path, (value, prevValue) => {
 
 const visible = computed(() => {
   if (props.isRemote) { return true }
+  if (!state.isVisibleInViewport) { return }
   return cards.value.startCard && cards.value.endCard
 })
 const isSpaceMember = computed(() => store.getters['currentUser/isSpaceMember']())

--- a/src/components/Connection.vue
+++ b/src/components/Connection.vue
@@ -2,7 +2,9 @@
 import { reactive, computed, onMounted, onBeforeUnmount, onUnmounted, defineProps, defineEmits, watch, ref, nextTick } from 'vue'
 import { useStore } from 'vuex'
 
+import ConnectionLabel from '@/components/ConnectionLabel.vue'
 import utils from '@/utils.js'
+
 const store = useStore()
 
 let animationTimer, isMultiTouch, startCursor, currentCursor
@@ -530,6 +532,8 @@ svg.connection(
     :data-relative-path="relativePath"
   )
     animateMotion(dur="3s" repeatCount="indefinite" :path="relativePath" rotate="auto")
+
+  ConnectionLabel(:connection="connection")
 </template>
 
 <style lang="stylus">

--- a/src/components/Connection.vue
+++ b/src/components/Connection.vue
@@ -268,6 +268,7 @@ const gradientId = computed(() => `gradient-${props.connection.id}`)
 const gradientIdReference = computed(() => `url('#${gradientId.value}')`)
 const directionIsVisible = computed(() => {
   checkIfShouldPauseConnectionDirections()
+  if (!visible.value) { return }
   return props.connection.directionIsVisible
 })
 const checkIfShouldPauseConnectionDirections = async () => {
@@ -501,7 +502,7 @@ defs(v-if="state.isVisibleInViewport")
     stop(offset="0%" :stop-color="typeColor" stop-opacity="0" fill-opacity="0")
     stop(offset="90%" :stop-color="typeColor")
 
-circle(v-if="directionIsVisible && !isUpdatingPath && state.isVisibleInViewport" r="7" :fill="gradientIdReference" :class="{filtered: isFiltered}" :data-id="connection.id")
+circle(v-if="directionIsVisible && !isUpdatingPath" r="7" :fill="gradientIdReference" :class="{filtered: isFiltered}" :data-id="connection.id")
   animateMotion(dur="3s" repeatCount="indefinite" :path="connection.path" rotate="auto")
 </template>
 

--- a/src/components/Connection.vue
+++ b/src/components/Connection.vue
@@ -57,25 +57,13 @@ const visible = computed(() => {
 const isSpaceMember = computed(() => store.getters['currentUser/isSpaceMember']())
 const canEditSpace = computed(() => store.getters['currentUser/canEditSpace']())
 
-// styles
+// styles and position
 
 const normalizedConnectionPathRect = () => {
   const pathStart = utils.startCoordsFromConnectionPath(props.connection.path)
   const pathEndRelative = utils.endCoordsFromConnectionPath(props.connection.path)
-  let rect = {
-    x: pathStart.x,
-    y: pathStart.y,
-    width: pathStart.x + pathEndRelative.x,
-    height: pathStart.y + pathEndRelative.y
-  }
-  if (pathEndRelative.x < 0) {
-    rect.x = pathStart.x + pathEndRelative.x
-    rect.width = rect.x + Math.abs(pathEndRelative.x)
-  }
-  if (pathEndRelative.y < 0) {
-    rect.y = pathStart.y + pathEndRelative.y
-    rect.height = rect.y + Math.abs(pathEndRelative.y)
-  }
+
+  const rect = utils.rectFromConnectionPathCoords(pathStart, pathEndRelative)
   return rect
 }
 const connectionStyles = computed(() => {
@@ -91,7 +79,6 @@ const connectionStyles = computed(() => {
   }
   return styles
 })
-
 const connectionPathStyles = computed(() => {
   const rect = normalizedConnectionPathRect()
   const styles = {
@@ -99,7 +86,6 @@ const connectionPathStyles = computed(() => {
   }
   return styles
 })
-
 const connectionPathClasses = computed(() => {
   let styles = {
     active: isActive.value,

--- a/src/components/ConnectionLabel.vue
+++ b/src/components/ConnectionLabel.vue
@@ -23,6 +23,16 @@ let touchPosition = {}
 let currentTouchPosition = {}
 
 onMounted(() => {
+  store.subscribe((mutation, state) => {
+    if (mutation.type === 'triggerUpdatePathWhileDragging') {
+      const connections = mutation.payload
+      if (!visible.value) { return }
+      connections.forEach(connection => {
+        if (connection.id !== props.connection.id) { return }
+        updateConnectionRect()
+      })
+    }
+  })
   window.addEventListener('mouseup', stopDragging)
   window.addEventListener('pointermove', drag)
   // wait for connection element to be in dom

--- a/src/components/Connections.vue
+++ b/src/components/Connections.vue
@@ -4,7 +4,6 @@ import { useStore } from 'vuex'
 
 import Connection from '@/components/Connection.vue'
 import CurrentConnection from '@/components/CurrentConnection.vue'
-import ConnectionLabel from '@/components/ConnectionLabel.vue'
 const store = useStore()
 
 const currentConnectionStartCardIds = computed(() => store.state.currentConnectionStartCardIds)
@@ -20,9 +19,6 @@ template(v-for="startCardId in currentConnectionStartCardIds")
     Connection(:connection="connection" :isRemote="true")
   template(v-for="connection in connections" :key="connection.id")
     Connection(:connection="connection")
-.labels
-  template(v-for="connection in connections" :key="connection.id")
-    ConnectionLabel(:connection="connection")
 </template>
 
 <style lang="stylus">

--- a/src/components/Connections.vue
+++ b/src/components/Connections.vue
@@ -13,19 +13,22 @@ const connections = computed(() => store.getters['currentConnections/all'])
 </script>
 
 <template lang="pug">
-svg.connections
+svg.current-connection
+  //- TODO refactor to not be page size svg (dynamic svg rect)
   template(v-for="startCardId in currentConnectionStartCardIds")
     CurrentConnection(:startCardId="startCardId")
+.connections
   template(v-for="connection in remoteCurrentConnections")
     Connection(:connection="connection" :isRemote="true")
   template(v-for="connection in connections" :key="connection.id")
     Connection(:connection="connection")
-template(v-for="connection in connections" :key="connection.id")
-  ConnectionLabel(:connection="connection")
+.labels
+  template(v-for="connection in connections" :key="connection.id")
+    ConnectionLabel(:connection="connection")
 </template>
 
 <style lang="stylus">
-svg.connections,
+svg.current-connection,
 .connection-labels
   position absolute
   top 0

--- a/src/components/Connections.vue
+++ b/src/components/Connections.vue
@@ -13,10 +13,8 @@ const connections = computed(() => store.getters['currentConnections/all'])
 </script>
 
 <template lang="pug">
-svg.current-connection
-  //- TODO refactor to not be page size svg (dynamic svg rect)
-  template(v-for="startCardId in currentConnectionStartCardIds")
-    CurrentConnection(:startCardId="startCardId")
+template(v-for="startCardId in currentConnectionStartCardIds")
+  CurrentConnection(:startCardId="startCardId")
 .connections
   template(v-for="connection in remoteCurrentConnections")
     Connection(:connection="connection" :isRemote="true")
@@ -28,14 +26,4 @@ svg.current-connection
 </template>
 
 <style lang="stylus">
-svg.current-connection,
-.connection-labels
-  position absolute
-  top 0
-  left 0
-  width 100%
-  height 100%
-  path
-    pointer-events all
-    cursor pointer
 </style>

--- a/src/components/Connections.vue
+++ b/src/components/Connections.vue
@@ -4,6 +4,7 @@ import { useStore } from 'vuex'
 
 import Connection from '@/components/Connection.vue'
 import CurrentConnection from '@/components/CurrentConnection.vue'
+import ConnectionLabel from '@/components/ConnectionLabel.vue'
 const store = useStore()
 
 const currentConnectionStartCardIds = computed(() => store.state.currentConnectionStartCardIds)
@@ -19,6 +20,9 @@ template(v-for="startCardId in currentConnectionStartCardIds")
     Connection(:connection="connection" :isRemote="true")
   template(v-for="connection in connections" :key="connection.id")
     Connection(:connection="connection")
+.labels
+  template(v-for="connection in connections" :key="connection.id")
+    ConnectionLabel(:connection="connection")
 </template>
 
 <style lang="stylus">

--- a/src/components/CurrentConnection.vue
+++ b/src/components/CurrentConnection.vue
@@ -155,19 +155,56 @@ const stopInteractions = (event) => {
   state.currentConnectionPath = undefined
 }
 
+// styles and position
+
+const normalizedConnectionPathRect = () => {
+  const path = state.currentConnectionPath
+  if (!path) { return }
+  const pathStart = utils.startCoordsFromConnectionPath(path)
+  const pathEndRelative = utils.endCoordsFromConnectionPath(path)
+  const rect = utils.rectFromConnectionPathCoords(pathStart, pathEndRelative)
+  return rect
+}
+const connectionStyles = computed(() => {
+  const rect = normalizedConnectionPathRect()
+  if (!rect) { return }
+  let styles = {
+    left: rect.x + 'px',
+    top: rect.y + 'px',
+    width: rect.width + 'px',
+    height: rect.height + 'px'
+  }
+  if (store.state.currentUserIsDraggingCard) {
+    styles.pointerEvents = 'none'
+  }
+  return styles
+})
+const connectionPathStyles = computed(() => {
+  const rect = normalizedConnectionPathRect()
+  if (!rect) { return }
+  const styles = {
+    transform: `translate(${-rect.x}px,${-rect.y}px)`
+  }
+  return styles
+})
+
 </script>
 
 <template lang="pug">
-path.current-connection(
-  v-if="isDrawingConnection"
-  fill="none"
-  stroke-width="5"
-  :stroke="state.currentConnectionColor"
-  :d="state.currentConnectionPath"
-)
+svg.current-connection(:style="connectionStyles")
+  path.current-connection-path(
+    v-if="isDrawingConnection"
+    fill="none"
+    stroke-width="5"
+    :stroke="state.currentConnectionColor"
+    :d="state.currentConnectionPath"
+    :style="connectionPathStyles"
+  )
 </template>
 
 <style lang="stylus">
-.current-connection
-  pointer-events none
+svg.current-connection
+  position absolute
+  path.current-connection-path
+    pointer-events none
 </style>

--- a/src/components/CurrentConnection.vue
+++ b/src/components/CurrentConnection.vue
@@ -160,9 +160,7 @@ const stopInteractions = (event) => {
 const normalizedConnectionPathRect = () => {
   const path = state.currentConnectionPath
   if (!path) { return }
-  const pathStart = utils.startCoordsFromConnectionPath(path)
-  const pathEndRelative = utils.endCoordsFromConnectionPath(path)
-  const rect = utils.rectFromConnectionPathCoords(pathStart, pathEndRelative)
+  const rect = utils.rectFromConnectionPath(path)
   return rect
 }
 const connectionStyles = computed(() => {

--- a/src/components/dialogs/About.vue
+++ b/src/components/dialogs/About.vue
@@ -205,7 +205,7 @@ dialog.about.narrow(v-if="visible" :open="visible" @click.left="closeDialogs" re
     .row
       .button-wrap
         button(@click.left.stop="changeSpaceToRoadmap")
-          span Roadmap
+          span 💐 Roadmap
     .row
       .button-wrap
         button(@click.left.stop="toggleAppsAndExtensionsIsVisible" :class="{active: state.appsAndExtensionsIsVisible}")

--- a/src/components/dialogs/CardDetails.vue
+++ b/src/components/dialogs/CardDetails.vue
@@ -19,6 +19,7 @@ import OtherSpacePreview from '@/components/OtherSpacePreview.vue'
 import utils from '@/utils.js'
 import consts from '@/consts.js'
 
+import debounce from 'lodash-es/debounce'
 import qs from '@aguezz/qs-parse'
 import { nanoid } from 'nanoid'
 
@@ -199,6 +200,10 @@ const updateDimensions = async (cardId) => {
   await nextTick()
   await nextTick()
 }
+const updateDimensionsAndPathsDebounced = debounce(async () => {
+  await updateDimensions()
+  updatePaths()
+}, 200)
 const scrollIntoViewAndFocus = async () => {
   let behavior
   if (utils.isIPhone()) {
@@ -366,8 +371,7 @@ const closeCard = async () => {
     store.dispatch('currentCards/remove', { id: cardId })
   }
   store.dispatch('updatePageSizes')
-  await nextTick()
-  await updateDimensions(cardId)
+  updateDimensionsAndPathsDebounced()
   store.dispatch('checkIfItemShouldIncreasePageSize', item)
   store.dispatch('history/resume')
   if (item.name || prevCardName) {
@@ -447,8 +451,7 @@ const updateCardName = async (newName) => {
   store.dispatch('currentCards/update', item)
   updateMediaUrls()
   updateTags()
-  await updateDimensions()
-  updatePaths()
+  updateDimensionsAndPathsDebounced()
   if (createdByUser.value.id !== store.state.currentUser.id) { return }
   if (state.notifiedMembers) { return } // send card update notifications only once per card, per session
   if (item.name) {
@@ -963,8 +966,7 @@ const removeUrlPreview = async () => {
   }
   store.commit('removeUrlPreviewLoadingForCardIds', cardId)
   store.dispatch('currentCards/update', update)
-  await updateDimensions()
-  updatePaths()
+  updateDimensionsAndPathsDebounced()
 }
 
 // media

--- a/src/components/layers/MagicPaint.vue
+++ b/src/components/layers/MagicPaint.vue
@@ -528,10 +528,13 @@ const selectBoxes = (points) => {
   store.dispatch('addMultipleToMultipleBoxesSelected', boxIds)
 }
 const selectConnections = (points) => {
-  const svg = document.querySelector('svg.connections')
-  const matches = collisionDetection.checkPointsInsidePaths(points, selectableConnectionsInViewport, svg)
-  const connectionIds = matches.map(match => match.id)
-  store.dispatch('addMultipleToMultipleConnectionsSelected', connectionIds)
+  const svgs = document.querySelectorAll('svg.connection')
+  svgs.forEach(svg => {
+    // TODO filter out non visible in viewport connections
+    const matches = collisionDetection.checkPointsInsidePaths(points, selectableConnectionsInViewport, svg)
+    const connectionIds = matches.map(match => match.id)
+    store.dispatch('addMultipleToMultipleConnectionsSelected', connectionIds)
+  })
 }
 
 // Remote Painting

--- a/src/components/layers/MagicPaint.vue
+++ b/src/components/layers/MagicPaint.vue
@@ -521,7 +521,7 @@ const selectBoxes = (points) => {
 const selectConnections = (points) => {
   const svgs = document.querySelectorAll('svg.connection')
   svgs.forEach(svg => {
-    // TODO filter out non visible in viewport connections
+    if (svg.dataset.isVisibleInViewport === 'false') { return }
     const matches = collisionDetection.checkPointsInsidePaths(points, selectableConnectionsInViewport, svg)
     const connectionIds = matches.map(match => match.id)
     store.dispatch('addMultipleToMultipleConnectionsSelected', connectionIds)

--- a/src/components/layers/MagicPaint.vue
+++ b/src/components/layers/MagicPaint.vue
@@ -171,18 +171,9 @@ const updateSelectableBoxes = () => {
   selectableBoxes = array
 }
 const updateSelectableConnectionsInViewport = () => {
-  let paths = []
-  const pathElements = document.querySelectorAll('svg .connection-path')
-  pathElements.forEach(path => {
-    const d = path.getAttribute('d')
-    const rect = utils.boundingBoxFromPath(d)
-    const isRectInsideViewport = utils.isRectInsideViewport(rect)
-    if (!isRectInsideViewport) { return }
-    // if (path.dataset.isVisibleInViewport === 'false') { return }
-    if (path.dataset.isHiddenByCommentFilter === 'true') { return }
-    paths.push(path)
-  })
-  selectableConnectionsInViewport = paths
+  const selectableConnections = store.getters['currentConnections/isSelectableInViewport']()
+  if (!selectableConnections) { return }
+  selectableConnectionsInViewport = selectableConnections
 }
 
 // position

--- a/src/components/layers/MagicPaint.vue
+++ b/src/components/layers/MagicPaint.vue
@@ -152,11 +152,13 @@ const updateSelectableCardsInViewport = () => {
   selectableCardsInViewport = selectableCards
   selectableCardsGrid = collisionDetection.createGrid(selectableCards)
 }
-const updateSelectableBoxes = () => {
+const updateSelectableBoxesInViewport = () => {
   const boxes = store.getters['currentBoxes/isNotLocked']
   let array = []
   boxes.forEach(box => {
     const element = document.querySelector(`.box-info[data-box-id="${box.id}"]`)
+    if (!element) { return }
+    if (element.dataset.isVisibleInViewport === 'false') { return }
     const rect = element.getBoundingClientRect()
     box = {
       id: box.id,
@@ -196,6 +198,7 @@ const userScroll = () => {
   // update selectable cards during paint autoscroll at edges
   if (store.state.currentUserIsPainting) {
     updateSelectableCardsInViewport()
+    updateSelectableBoxesInViewport()
     updateSelectableConnectionsInViewport()
   }
   scroll()
@@ -414,7 +417,7 @@ const startPainting = (event) => {
   if (isBoxSelecting.value) { return }
   if (store.state.isPinchZooming) { return }
   updateSelectableCardsInViewport()
-  updateSelectableBoxes()
+  updateSelectableBoxesInViewport()
   updateSelectableConnectionsInViewport()
   startCursor = utils.cursorPositionInViewport(event)
   state.currentCursor = startCursor

--- a/src/data/new.json
+++ b/src/data/new.json
@@ -22,8 +22,8 @@
       "y": 140,
       "z": 0,
       "name": "Get your thoughts, ideas and feelings out",
-      "width": 235,
-      "height": 49
+      "width": 200,
+      "height": 51
     },
     {
       "id": "wQ9-NzxQyWoIGGKEgHRMF",
@@ -31,8 +31,8 @@
       "y": 220,
       "name": "Connect them together\n\n[Help and Tutorials](https://help.kinopio.club)",
       "z": 3,
-      "width": 184,
-      "height": 65
+      "width": 193,
+      "height": 69
     }
   ],
   "connections": [

--- a/src/store/currentBoxes.js
+++ b/src/store/currentBoxes.js
@@ -500,6 +500,16 @@ export default {
     all: (state) => {
       return state.ids.map(id => state.boxes[id])
     },
+    isSelectableInViewport: (state, getters) => {
+      const elements = document.querySelectorAll('.box')
+      let boxes = []
+      elements.forEach(box => {
+        if (box.dataset.isVisibleInViewport === 'false') { return }
+        boxes.push(box)
+      })
+      boxes = boxes.map(box => getters.byId(box.dataset.boxId))
+      return boxes
+    },
     isSelectedIds: (state, getters, rootState, rootGetters) => {
       const currentDraggingId = rootState.currentDraggingBoxId
       const multipleSelectedIds = rootState.multipleBoxesSelectedIds

--- a/src/store/currentCards.js
+++ b/src/store/currentCards.js
@@ -420,7 +420,9 @@ const currentCards = {
           cards: [],
           spaceId: context.rootState.currentSpace.id
         }
-        const cardIds = cards.map(newCard => newCard.id)
+        let cardIds = cards.map(newCard => newCard.id)
+        cardIds = cardIds.filter(cardId => Boolean(cardId))
+        if (!cardIds) { return }
         context.commit('shouldExplicitlyRenderCardIds', cardIds, { root: true })
         const updatedCards = cards.filter(card => Boolean(card))
         updatedCards.forEach(card => {

--- a/src/store/currentConnections.js
+++ b/src/store/currentConnections.js
@@ -456,6 +456,16 @@ export default {
       const connections = connectionIds.map(id => getters.byId(id))
       return connections
     },
+    isSelectableInViewport: (state, getters) => () => {
+      const elements = document.querySelectorAll('svg.connection path.connection-path')
+      let paths = []
+      elements.forEach(path => {
+        if (path.dataset.isVisibleInViewport === 'false') { return }
+        if (path.dataset.isHiddenByCommentFilter === 'true') { return }
+        paths.push(path)
+      })
+      return paths
+    },
     connectionsWithValidCards: (state, getters, rootState, rootGetters) => (connections) => {
       connections = connections.filter(connection => {
         const startCard = rootGetters['currentCards/byId'](connection.startCardId)

--- a/src/store/currentConnections.js
+++ b/src/store/currentConnections.js
@@ -83,7 +83,7 @@ export default {
     },
     updatePathsWhileDragging: (state, connections) => {
       connections.forEach(connection => {
-        const connectionElement = document.querySelector(`g.connection[data-id="${connection.id}"]`)
+        const connectionElement = document.querySelector(`svg.connection[data-id="${connection.id}"]`)
         const pathElement = connectionElement.querySelector('path')
         pathElement.setAttribute('d', connection.path)
       })

--- a/src/store/currentConnections.js
+++ b/src/store/currentConnections.js
@@ -85,6 +85,7 @@ export default {
       connections.forEach(connection => {
         const connectionElement = document.querySelector(`svg.connection[data-id="${connection.id}"]`)
         const pathElement = connectionElement.querySelector('path')
+        if (!pathElement) { return }
         pathElement.setAttribute('d', connection.path)
       })
     },

--- a/src/store/currentConnections.js
+++ b/src/store/currentConnections.js
@@ -310,6 +310,7 @@ export default {
         newConnections.push(newConnection)
       })
       context.commit('updatePathsWhileDragging', newConnections)
+      context.commit('triggerUpdatePathWhileDragging', newConnections, { root: true })
       context.dispatch('broadcast/update', { updates: { connections: newConnections }, type: 'updateConnection', handler: 'currentConnections/updatePathsBroadcast' }, { root: true })
     },
     correctPaths: (context, { shouldUpdateApi }) => {

--- a/src/store/currentSpace.js
+++ b/src/store/currentSpace.js
@@ -1034,7 +1034,6 @@ const currentSpace = {
       })
     },
     unpauseConnectionDirections: (context, space) => {
-      // TODO only unpause/animate if connection is visible in viewport
       const svgs = document.querySelectorAll('svg.connection')
       svgs.forEach(svg => {
         svg.unpauseAnimations()

--- a/src/store/currentSpace.js
+++ b/src/store/currentSpace.js
@@ -1027,13 +1027,18 @@ const currentSpace = {
       context.commit('newTweetCards', cards, { root: true })
     },
     pauseConnectionDirections: (context, space) => {
-      const svg = document.querySelector('svg.connections')
-      svg.pauseAnimations()
-      svg.setCurrentTime(1.5)
+      const svgs = document.querySelectorAll('svg.connection')
+      svgs.forEach(svg => {
+        svg.pauseAnimations()
+        svg.setCurrentTime(1.5)
+      })
     },
     unpauseConnectionDirections: (context, space) => {
-      const svg = document.querySelector('svg.connections')
-      svg.unpauseAnimations()
+      // TODO only unpause/animate if connection is visible in viewport
+      const svgs = document.querySelectorAll('svg.connection')
+      svgs.forEach(svg => {
+        svg.unpauseAnimations()
+      })
     },
     checkIfShouldNotifySignUpToEditSpace: (context, space) => {
       const spaceIsOpen = space.privacy === 'open'

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -605,6 +605,7 @@ const store = createStore({
     triggerCheckIfShouldNotifySpaceOutOfSync: () => {},
     triggerNotifyOffscreenCardCreated: (state, card) => {},
     triggerSonarPing: (state, event) => {},
+    triggerUpdatePathWhileDragging: (state, connections) => {},
 
     // Used by extensions only
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1190,7 +1190,7 @@ export default {
       rect.y = pathStart.y + pathEndRelative.y
       rect.height = Math.abs(pathEndRelative.y)
     }
-    const padding = 40
+    const padding = 90 // control point max
     rect.width = rect.width + padding
     rect.height = rect.height + padding
     return rect

--- a/src/utils.js
+++ b/src/utils.js
@@ -1175,6 +1175,23 @@ export default {
     }
     return this.integerCoords(coords)
   },
+  rectFromConnectionPathCoords (pathStart, pathEndRelative) {
+    let rect = {
+      x: pathStart.x,
+      y: pathStart.y,
+      width: pathStart.x + pathEndRelative.x,
+      height: pathStart.y + pathEndRelative.y
+    }
+    if (pathEndRelative.x < 0) {
+      rect.x = pathStart.x + pathEndRelative.x
+      rect.width = rect.x + Math.abs(pathEndRelative.x)
+    }
+    if (pathEndRelative.y < 0) {
+      rect.y = pathStart.y + pathEndRelative.y
+      rect.height = rect.y + Math.abs(pathEndRelative.y)
+    }
+    return rect
+  },
   integerCoords (coords) {
     return {
       x: parseInt(coords.x),

--- a/src/utils.js
+++ b/src/utils.js
@@ -1175,7 +1175,9 @@ export default {
     }
     return this.integerCoords(coords)
   },
-  rectFromConnectionPathCoords (pathStart, pathEndRelative) {
+  rectFromConnectionPath (path) {
+    const pathStart = this.startCoordsFromConnectionPath(path)
+    const pathEndRelative = this.endCoordsFromConnectionPath(path)
     let rect = {
       x: pathStart.x,
       y: pathStart.y,
@@ -1190,10 +1192,9 @@ export default {
       rect.y = pathStart.y + pathEndRelative.y
       rect.height = Math.abs(pathEndRelative.y)
     }
-    const controlPointMaxX = 90 // q90,40
-    const controlPointMaxY = 40
-    rect.width = rect.width + controlPointMaxX
-    rect.height = rect.height + controlPointMaxY
+    let controlPointMax = this.curveControlPointFromPath(path)
+    rect.width = rect.width + controlPointMax.x
+    rect.height = rect.height + controlPointMax.y
     return rect
   },
   integerCoords (coords) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1179,17 +1179,20 @@ export default {
     let rect = {
       x: pathStart.x,
       y: pathStart.y,
-      width: pathStart.x + pathEndRelative.x,
-      height: pathStart.y + pathEndRelative.y
+      width: pathEndRelative.x,
+      height: pathEndRelative.y
     }
     if (pathEndRelative.x < 0) {
       rect.x = pathStart.x + pathEndRelative.x
-      rect.width = rect.x + Math.abs(pathEndRelative.x)
+      rect.width = Math.abs(pathEndRelative.x)
     }
     if (pathEndRelative.y < 0) {
       rect.y = pathStart.y + pathEndRelative.y
-      rect.height = rect.y + Math.abs(pathEndRelative.y)
+      rect.height = Math.abs(pathEndRelative.y)
     }
+    const padding = 40
+    rect.width = rect.width + padding
+    rect.height = rect.height + padding
     return rect
   },
   integerCoords (coords) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1190,9 +1190,10 @@ export default {
       rect.y = pathStart.y + pathEndRelative.y
       rect.height = Math.abs(pathEndRelative.y)
     }
-    const padding = 90 // control point max
-    rect.width = rect.width + padding
-    rect.height = rect.height + padding
+    const controlPointMaxX = 90 // q90,40
+    const controlPointMaxY = 40
+    rect.width = rect.width + controlPointMaxX
+    rect.height = rect.height + controlPointMaxY
     return rect
   },
   integerCoords (coords) {


### PR DESCRIPTION
moving from a single page sized svg parent , to 1 svg parent per connection. inspired by a how tldraw renders shapes

smoothness increased, paint selection speed increased, card dragging and card name updating perf increased.

connection labels and direction animations update while you drag

https://github.com/kinopio-club/kinopio-client/assets/877072/ac7d2e22-3fe2-4009-b550-ccfb7d226039

