### PR TITLE
fix regex for urls with '.1' at the end

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1961,15 +1961,15 @@ export default {
       })
     }
     string = this.removeMarkdownCodeblocksFromString(string)
+    // matches multiple urls and returns [urls]
     // https://regexr.com/59m5t
     // start, newline, or space
     // starts with http/s protocol
     // followed by alphanumerics
     // then '.', or ':' + portnumbers
-    // followed by alphanumerics
-    // then trailing '/' or '-'
-    // matches multiple urls and returns [urls]
-    const urlPattern = new RegExp(/(^|\n| )(http[s]?:\/\/)[^\s(["<>]{1,}(\.|(:[0-9]+))[^\s."><]+[\w=]\/?-?/igm)
+    // followed by at least 1 alphanumeric, '=', or '.'
+    // then optional trailing '/' or '-'
+    const urlPattern = new RegExp(/(^|\n| )(http[s]?:\/\/)[^\s(["<>]{1,}(\.|(:[0-9]+))[^\s."><]+[\w=.]+\/?-?/igm)
     let localhostUrls = string.match(this.localhostUrlPattern()) || []
     let urls = string.match(urlPattern) || []
     urls = urls.concat(localhostUrls)


### PR DESCRIPTION
eg https://www.biblegateway.com/audio/purevoice/niv/Gen.1 
https://club.kinopio.club/t/url-preview-while-typing/1372/2?u=pirijan
![CleanShot 2024-08-28 at 11 47 11@2x](https://github.com/user-attachments/assets/0b4c6ad5-cb5f-406b-8f5c-ea9edc50cb40)
