### PR TITLE
Box checkbox

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1242,6 +1242,9 @@ code
   opacity 0
   pointer-events none !important
 
+.space-is-hidden
+  opacity 0.5
+
 .fade-out
   opacity 0
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -974,11 +974,6 @@ li
       background-image url('assets/checkmark.svg')
       background-repeat no-repeat
       background-position center
-    &.add
-      background-image url('assets/add.svg')
-      background-repeat no-repeat
-      background-position center
-      background-size 69%
 
 details
   summary

--- a/src/App.vue
+++ b/src/App.vue
@@ -867,10 +867,13 @@ button
 .is-dark-theme
   .icon
     filter invert()
-
 .icon
   user-drag none
   -webkit-user-drag none
+  &.is-background-light
+    filter none
+  &.is-background-dark
+    filter invert(1)
 
 .icon + span,
 .icon + .icon

--- a/src/App.vue
+++ b/src/App.vue
@@ -1140,7 +1140,6 @@ code
     padding 0px 7px
     vertical-align 0
     margin-right 5px
-    border-radius var(--small-entity-radius)
   &.badge-card-button
     box-shadow none
     text-decoration none

--- a/src/assets/connect-items.svg
+++ b/src/assets/connect-items.svg
@@ -1,0 +1,1 @@
+<svg height="12" viewBox="0 0 26 12" width="26" xmlns="http://www.w3.org/2000/svg"><g fill="none" fill-rule="evenodd" stroke="#000" stroke-linecap="square" stroke-linejoin="round"><circle cx="5.5" cy="6" r="5"/><circle cx="19.666667" cy="6" r="5"/><path d="m10.5 5.583333h3.333333"/></g></svg>

--- a/src/components/Box.vue
+++ b/src/components/Box.vue
@@ -810,7 +810,11 @@ const containingBoxes = computed(() => {
   boxes = boxes.filter(box => {
     box = utils.clone(box)
     const currentBox = utils.clone(props.box)
-    return utils.isRectAInsideRectB(currentBox, box)
+    const isInsideBox = utils.isRectAInsideRectB(currentBox, box)
+    const boxArea = box.resizeWidth * box.resizeHeight
+    const currentBoxArea = currentBox.resizeWidth * currentBox.resizeHeight
+    const boxIsParent = boxArea > currentBoxArea
+    return isInsideBox && boxIsParent
   })
   return boxes
 })

--- a/src/components/Box.vue
+++ b/src/components/Box.vue
@@ -71,6 +71,7 @@ const state = reactive({
 const spaceCounterZoomDecimal = computed(() => store.getters.spaceCounterZoomDecimal)
 const canEditBox = computed(() => store.getters['currentUser/canEditBox'](props.box))
 const currentUserIsSignedIn = computed(() => store.getters['currentUser/isSignedIn'])
+const name = computed(() => props.box.name)
 
 // normalize
 
@@ -88,6 +89,16 @@ const normalizeBox = (box) => {
   box.fill = box.fill || 'filled'
   return box
 }
+const normalizedName = computed(() => {
+  // name without checkbox text
+  let newName = name.value
+  if (!newName) { return }
+  const checkbox = utils.checkboxFromString(newName)
+  if (checkbox) {
+    newName = newName.replace(checkbox, '')
+  }
+  return newName.trim()
+})
 
 // should render
 
@@ -601,8 +612,8 @@ const isH2 = computed(() => {
   const pattern = 'h2Pattern'
   return nameHasPattern(pattern)
 })
-const h1Name = computed(() => props.box.name.replace('# ', ''))
-const h2Name = computed(() => props.box.name.replace('## ', ''))
+const h1Name = computed(() => normalizedName.value.replace('# ', ''))
+const h2Name = computed(() => normalizedName.value.replace('## ', ''))
 const nameHasPattern = (pattern) => {
   const result = utils.markdown()[pattern].exec(props.box.name)
   return Boolean(result)
@@ -763,6 +774,33 @@ const updateRemoteConnections = () => {
     state.isRemoteConnecting = false
   }
 }
+
+// checkbox
+
+const isChecked = computed(() => utils.nameIsChecked(name.value))
+const hasCheckbox = computed(() => {
+  return utils.checkboxFromString(name.value)
+})
+const checkboxState = computed({
+  get () {
+    return isChecked.value
+  }
+})
+const toggleBoxChecked = () => {
+  if (store.state.preventDraggedBoxFromShowingDetails) { return }
+  if (!canEditSpace.value) { return }
+  const value = !isChecked.value
+  store.dispatch('closeAllDialogs')
+  store.dispatch('currentBoxes/toggleChecked', { boxId: props.box.id, value })
+  postMessage.sendHaptics({ name: 'heavyImpact' })
+  cancelLocking()
+  store.commit('currentUserIsDraggingBox', false)
+  const userId = store.state.currentUser.id
+  store.commit('broadcast/updateStore', { updates: { userId }, type: 'clearRemoteBoxesDragging' })
+  event.stopPropagation()
+  store.commit('preventMultipleSelectedActionsIsVisible', false)
+  store.dispatch('clearMultipleSelected')
+}
 </script>
 
 <template lang="pug">
@@ -803,14 +841,19 @@ const updateRemoteConnections = () => {
     @touchend="endBoxInfoInteractionTouch"
   )
     .locking-frame(v-if="state.isLocking" :style="lockingFrameStyle")
-    template(v-if="isH1")
-      h1 {{h1Name}}
-    template(v-else-if="isH2")
-      h2 {{h2Name}}
-    template(v-else)
-      span {{box.name}}
-    .selected-user-avatar(v-if="isRemoteSelected || isRemoteBoxDetailsVisible" :style="{backgroundColor: remoteSelectedColor || remoteBoxDetailsVisibleColor}")
-      img(src="@/assets/anon-avatar.svg")
+    //- [·]
+    .checkbox-wrap(v-if="hasCheckbox" @mouseup.left="toggleBoxChecked" @touchend.prevent="toggleBoxChecked")
+      label(:class="{active: isChecked, disabled: !canEditSpace}")
+        input(name="checkbox" type="checkbox" v-model="checkboxState")
+    .name-wrap
+      template(v-if="isH1")
+        h1 {{h1Name}}
+      template(v-else-if="isH2")
+        h2 {{h2Name}}
+      template(v-else)
+        span {{normalizedName}}
+      .selected-user-avatar(v-if="isRemoteSelected || isRemoteBoxDetailsVisible" :style="{backgroundColor: remoteSelectedColor || remoteBoxDetailsVisibleColor}")
+        img(src="@/assets/anon-avatar.svg")
 
   ItemConnectorButton(
     :visible="connectorIsVisible"
@@ -916,8 +959,6 @@ const updateRemoteConnections = () => {
     pointer-events all
     position absolute
     cursor pointer
-    padding 6px 8px
-    padding-right 10px
     border-bottom-right-radius var(--entity-radius)
     word-break break-word
     color var(--primary-on-light-background)
@@ -928,6 +969,49 @@ const updateRemoteConnections = () => {
     &.is-dark
       color var(--primary-on-dark-background)
 
+  .checkbox-wrap
+    padding-left 8px
+    padding-top 5px
+    padding-bottom 6px
+    display inline-block
+    label
+      pointer-events none
+      width 20px
+      height 16px
+      display flex
+      align-items center
+      padding-left 4px
+      padding-right 4px
+      input
+        margin 0
+        margin-top -1px
+        width 10px
+        height 10px
+        background-size contain
+    &:hover
+      label
+        box-shadow 3px 3px 0 var(--heavy-shadow)
+        background-color var(--secondary-hover-background)
+        input
+          background-color var(--secondary-hover-background)
+      label.active
+        box-shadow var(--active-inset-shadow)
+        background-color var(--secondary-active-background)
+        input
+          background-color var(--secondary-active-background)
+    &:active
+      label
+        box-shadow none
+        color var(--primary)
+        background-color var(--secondary-active-background)
+      input
+        background-color var(--secondary-active-background)
+
+  .name-wrap
+    padding 6px 8px
+    padding-top 4px
+    padding-right 10px
+    display inline-block
   h1
     font-family var(--header-font)
     font-size 20px

--- a/src/components/Box.vue
+++ b/src/components/Box.vue
@@ -804,6 +804,8 @@ const toggleBoxChecked = () => {
   event.stopPropagation()
   store.commit('preventMultipleSelectedActionsIsVisible', false)
   store.dispatch('clearMultipleSelected')
+  store.commit('currentDraggingBoxId', '')
+  store.dispatch('multipleBoxesSelectedIds', [])
 }
 const containingBoxes = computed(() => {
   if (!state.isVisibleInViewport) { return }

--- a/src/components/Box.vue
+++ b/src/components/Box.vue
@@ -801,6 +801,24 @@ const toggleBoxChecked = () => {
   store.commit('preventMultipleSelectedActionsIsVisible', false)
   store.dispatch('clearMultipleSelected')
 }
+const containingBoxes = computed(() => {
+  if (!state.isVisibleInViewport) { return }
+  if (isDragging.value) { return }
+  if (isSelected.value) { return }
+  if (isResizing.value) { return }
+  let boxes = store.getters['currentBoxes/all']
+  boxes = boxes.filter(box => {
+    box = utils.clone(box)
+    const currentBox = utils.clone(props.box)
+    return utils.isRectAInsideRectB(currentBox, box)
+  })
+  return boxes
+})
+const isInCheckedBox = computed(() => {
+  if (!containingBoxes.value) { return }
+  const checkedBox = containingBoxes.value.find(box => utils.nameIsChecked(box.name))
+  return Boolean(checkedBox)
+})
 </script>
 
 <template lang="pug">
@@ -816,7 +834,7 @@ const toggleBoxChecked = () => {
   :data-should-render="shouldRender"
 
   :style="styles"
-  :class="{hover: state.isHover, active: isDragging, 'box-jiggle': shouldJiggle, 'is-resizing': isResizing, 'is-selected': isSelected}"
+  :class="{hover: state.isHover, active: isDragging, 'box-jiggle': shouldJiggle, 'is-resizing': isResizing, 'is-selected': isSelected, 'is-checked': isChecked || isInCheckedBox}"
   ref="boxElement"
 )
 
@@ -917,6 +935,8 @@ const toggleBoxChecked = () => {
     transition none
   &.is-selected
     transition none
+  &.is-checked
+    opacity 0.5
   .box-info
     --header-font var(--header-font-0)
     &.header-font-1

--- a/src/components/Box.vue
+++ b/src/components/Box.vue
@@ -312,6 +312,10 @@ const startResizing = (event) => {
   store.commit('broadcast/updateStore', { updates, type: 'updateRemoteUserResizingBoxes' })
   event.preventDefault() // allows resizing box without scrolling on mobile
 }
+const resizeColorClass = computed(() => {
+  const colorClass = utils.colorClasses({ backgroundColorIsDark: colorIsDark.value })
+  return [colorClass]
+})
 
 // shrink
 
@@ -904,7 +908,7 @@ const isInCheckedBox = computed(() => {
       button.inline-button(
         tabindex="-1"
       )
-        img.resize-icon.icon(src="@/assets/resize-corner.svg")
+        img.resize-icon.icon(src="@/assets/resize-corner.svg" :class="resizeColorClass")
 
   //- fill
   .background.filled(v-if="hasFill" :style="{background: color}")

--- a/src/components/Box.vue
+++ b/src/components/Box.vue
@@ -845,7 +845,7 @@ const toggleBoxChecked = () => {
     .checkbox-wrap(v-if="hasCheckbox" @mouseup.left="toggleBoxChecked" @touchend.prevent="toggleBoxChecked")
       label(:class="{active: isChecked, disabled: !canEditSpace}")
         input(name="checkbox" type="checkbox" v-model="checkboxState")
-    .name-wrap
+    .name-wrap(:class="{'is-checked': isChecked}")
       template(v-if="isH1")
         h1 {{h1Name}}
       template(v-else-if="isH2")
@@ -1012,6 +1012,8 @@ const toggleBoxChecked = () => {
     padding-top 4px
     padding-right 10px
     display inline-block
+    &.is-checked
+      text-decoration line-through
   h1
     font-family var(--header-font)
     font-size 20px

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -444,7 +444,8 @@ const cardClasses = computed(() => {
     'is-locked': isLocked.value,
     'has-url-preview': cardUrlPreviewIsVisible.value,
     'is-dark': backgroundColorIsDark.value,
-    'child-is-hovered': currentUserIsHoveringOverUrlButton.value && !currentCardIsBeingDragged.value
+    'child-is-hovered': currentUserIsHoveringOverUrlButton.value && !currentCardIsBeingDragged.value,
+    'is-in-checked-box': isInCheckedBox.value
   }
   classes = addSizeClasses(classes)
   return classes
@@ -1766,6 +1767,26 @@ const checkIfShouldUpdateIframeUrl = () => {
   }
 }
 
+// containing box
+
+const containingBoxes = computed(() => {
+  if (!state.isVisibleInViewport) { return }
+  if (isSelectedOrDragging.value) { return }
+  if (currentCardIsBeingDragged.value) { return }
+  let boxes = store.getters['currentBoxes/all']
+  boxes = boxes.filter(box => {
+    box = utils.clone(box)
+    const card = utils.clone(props.card)
+    return utils.isRectAInsideRectB(card, box)
+  })
+  return boxes
+})
+const isInCheckedBox = computed(() => {
+  if (!containingBoxes.value) { return }
+  const checkedBox = containingBoxes.value.find(box => utils.nameIsChecked(box.name))
+  return Boolean(checkedBox)
+})
+
 </script>
 
 <template lang="pug">
@@ -2302,6 +2323,9 @@ article.card-wrap
     img
       width 10px
       height 10px
+
+  .is-in-checked-box
+    opacity 0.5
 
 @keyframes bounce
   0%

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -228,7 +228,6 @@ const removeCommentBrackets = (name) => {
 
 const isChecked = computed(() => utils.nameIsChecked(name.value))
 const hasCheckbox = computed(() => {
-  if (isLocked.value) { return }
   return utils.checkboxFromString(name.value)
 })
 const checkboxState = computed({

--- a/src/components/ConnectionDecorators.vue
+++ b/src/components/ConnectionDecorators.vue
@@ -153,7 +153,4 @@ button
     &.reverse,
     &.connection-path
       vertical-align 0
-.subsection
-  .button-wrap
-    margin-bottom 4px !important
 </style>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -657,17 +657,17 @@ header(v-if="isVisible" :style="state.position" :class="{'fade-out': isFadingOut
             //- Current Space Name and Info
             .button-wrap.space-name-button-wrap(:class="{ 'back-button-is-visible': backButtonIsVisible }")
               button.space-name-button(@click.left.stop="toggleSpaceDetailsIsVisible" :class="{ active: state.spaceDetailsIsVisible, 'translucent-button': !shouldIncreaseUIContrast }")
-                TeamLabel(:team="spaceTeam")
-                span(v-if="currentSpaceIsInbox")
-                  img.icon.inbox-icon(src="@/assets/inbox.svg")
-                span(v-if="currentSpaceIsTemplate")
-                  img.icon.templates(src="@/assets/templates.svg")
-                SpaceTodayJournalBadge(:space="currentSpace")
-                MoonPhase(v-if="currentSpace.moonPhase" :moonPhase="currentSpace.moonPhase")
-                span {{currentSpaceName}}
-                  PrivacyIcon(:privacy="currentSpace.privacy" :closedIsNotVisible="true")
-                img.icon.sunglasses.explore(src="@/assets/sunglasses.svg" v-if="shouldShowInExplore" title="Shown in Explore")
-                img.icon.view-hidden(v-if="currentSpaceIsHidden" src="@/assets/view-hidden.svg")
+                .button-contents(:class="{'space-is-hidden': currentSpaceIsHidden}")
+                  TeamLabel(:team="spaceTeam")
+                  span(v-if="currentSpaceIsInbox")
+                    img.icon.inbox-icon(src="@/assets/inbox.svg")
+                  span(v-if="currentSpaceIsTemplate")
+                    img.icon.templates(src="@/assets/templates.svg")
+                  SpaceTodayJournalBadge(:space="currentSpace")
+                  MoonPhase(v-if="currentSpace.moonPhase" :moonPhase="currentSpace.moonPhase")
+                  span {{currentSpaceName}}
+                    PrivacyIcon(:privacy="currentSpace.privacy" :closedIsNotVisible="true")
+                  img.icon.sunglasses.explore(src="@/assets/sunglasses.svg" v-if="shouldShowInExplore" title="Shown in Explore")
               SpaceDetails(:visible="state.spaceDetailsIsVisible")
               ImportArenaChannel(:visible="importArenaChannelIsVisible")
               SpaceDetailsInfo(:visible="state.spaceDetailsInfoIsVisible")
@@ -943,6 +943,9 @@ header
     span
       width 100%
       color var(--primary)
+
+  .space-is-hidden
+    opacity 0.5
 
 .badge-jiggle
   animation-name notificationJiggle

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -944,9 +944,6 @@ header
       width 100%
       color var(--primary)
 
-  .space-is-hidden
-    opacity 0.5
-
 .badge-jiggle
   animation-name notificationJiggle
   animation-duration 0.4s

--- a/src/components/ItemCheckboxButton.vue
+++ b/src/components/ItemCheckboxButton.vue
@@ -111,12 +111,12 @@ const updateDimensionsAndPaths = async () => {
 .button-wrap.items-checkboxes.checkbox-button(:class="{ disabled: isDisabled }" title="Toggle Checkboxes")
   label.fixed-height(v-if="state.itemsHaveCheckboxes" :class="{active: state.itemsCheckboxIsChecked}" tabindex="0")
     input(type="checkbox" v-model="itemCheckboxes" tabindex="-1")
-  label.fixed-height(v-if="!state.itemsHaveCheckboxes" @click.left.prevent="addCheckboxToItems" @keydown.stop.enter="addCheckboxToItems" tabindex="0")
+  label.fixed-height(v-if="!state.itemsHaveCheckboxes" @click.left.prevent="addCheckboxToItems" @keydown.stop.enter="addCheckboxToItems" tabindex="0" title="Add Checkboxes")
     input.add(type="checkbox" tabindex="-1")
 </template>
 
 <style lang="stylus">
 .checkbox-button
   input
-    margin 0
+    margin 0 !important
 </style>

--- a/src/components/ItemCheckboxButton.vue
+++ b/src/components/ItemCheckboxButton.vue
@@ -27,6 +27,15 @@ const props = defineProps({
     }
   }
 })
+watch(() => props.cards, async (value, prevValue) => {
+  checkItemsHaveCheckboxes()
+  checkItemsCheckboxIsChecked()
+})
+watch(() => props.boxes, async (value, prevValue) => {
+  checkItemsHaveCheckboxes()
+  checkItemsCheckboxIsChecked()
+})
+
 const state = reactive({
   itemsHaveCheckboxes: false,
   itemsCheckboxIsChecked: false

--- a/src/components/ItemCheckboxButton.vue
+++ b/src/components/ItemCheckboxButton.vue
@@ -1,0 +1,122 @@
+<script setup>
+import { reactive, computed, onMounted, onBeforeUnmount, defineProps, defineEmits, watch, ref, nextTick } from 'vue'
+import { useStore } from 'vuex'
+
+import utils from '@/utils.js'
+const store = useStore()
+
+onMounted(() => {
+  checkItemsHaveCheckboxes()
+  checkItemsCheckboxIsChecked()
+})
+
+const emit = defineEmits(['updateCount'])
+
+const props = defineProps({
+  isDisabled: Boolean,
+  boxes: {
+    type: Array,
+    default: () => {
+      return []
+    }
+  },
+  cards: {
+    type: Array,
+    default: () => {
+      return []
+    }
+  }
+})
+const state = reactive({
+  itemsHaveCheckboxes: false,
+  itemsCheckboxIsChecked: false
+})
+
+const items = computed(() => props.cards.concat(props.boxes))
+const itemCheckboxes = computed({
+  get () {
+    return state.itemsCheckboxIsChecked
+  },
+  set (value) {
+    // remove checkbox
+    if (state.itemsCheckboxIsChecked) {
+      props.cards.forEach(card => {
+        store.dispatch('currentCards/removeChecked', card.id)
+      })
+      props.boxes.forEach(box => {
+        store.dispatch('currentBoxes/removeChecked', box.id)
+      })
+    // add checkbox
+    } else {
+      props.cards.forEach(card => {
+        store.dispatch('currentCards/toggleChecked', { cardId: card.id, value })
+      })
+      props.boxes.forEach(box => {
+        store.dispatch('currentBoxes/toggleChecked', { boxId: box.id, value })
+      })
+    }
+    checkItemsHaveCheckboxes()
+    checkItemsCheckboxIsChecked()
+    updateDimensionsAndPaths()
+  }
+})
+const checkItemsHaveCheckboxes = () => {
+  const itemsWithCheckboxes = items.value.filter(item => {
+    if (!item) { return }
+    return utils.checkboxFromString(item.name)
+  })
+  state.itemsHaveCheckboxes = itemsWithCheckboxes.length === items.value.length
+}
+const checkItemsCheckboxIsChecked = () => {
+  const itemsChecked = items.value.filter(item => utils.nameIsChecked(item.name))
+  state.itemsCheckboxIsChecked = itemsChecked.length === items.value.length
+}
+const addCheckboxToItems = async () => {
+  let updatedCards = []
+  let updatedBoxes = []
+  // cards
+  props.cards.forEach(card => {
+    if (!utils.checkboxFromString(card.name)) {
+      const update = {
+        id: card.id,
+        name: `[] ${card.name}`
+      }
+      updatedCards.push(update)
+    }
+  })
+  store.dispatch('currentCards/updateMultiple', updatedCards)
+  // boxes
+  props.boxes.forEach(box => {
+    if (!utils.checkboxFromString(box.name)) {
+      const update = {
+        id: box.id,
+        name: `[] ${box.name}`
+      }
+      updatedBoxes.push(update)
+    }
+  })
+  store.dispatch('currentBoxes/updateMultiple', updatedBoxes)
+  state.itemsHaveCheckboxes = true
+  updateDimensionsAndPaths()
+}
+const updateDimensionsAndPaths = async () => {
+  store.dispatch('currentCards/updateDimensions', { cards: props.cards })
+  await nextTick()
+  await nextTick()
+  store.dispatch('currentConnections/updateMultiplePaths', props.cards)
+}
+</script>
+
+<template lang="pug">
+.button-wrap.items-checkboxes.checkbox-button(:class="{ disabled: isDisabled }" title="Toggle Checkboxes")
+  label.fixed-height(v-if="state.itemsHaveCheckboxes" :class="{active: state.itemsCheckboxIsChecked}" tabindex="0")
+    input(type="checkbox" v-model="itemCheckboxes" tabindex="-1")
+  label.fixed-height(v-if="!state.itemsHaveCheckboxes" @click.left.prevent="addCheckboxToItems" @keydown.stop.enter="addCheckboxToItems" tabindex="0")
+    input.add(type="checkbox" tabindex="-1")
+</template>
+
+<style lang="stylus">
+.checkbox-button
+  input
+    margin 0
+</style>

--- a/src/components/NameSegment.vue
+++ b/src/components/NameSegment.vue
@@ -51,11 +51,11 @@ const nameSegmentClasses = computed(() => {
 const smartQuotes = (string) => {
   return smartquotes(string)
 }
-const textColorClasses = computed(() => {
-  return utils.textColorClasses({ backgroundColorIsDark: props.backgroundColorIsDark })
+const colorClasses = computed(() => {
+  return utils.colorClasses({ backgroundColorIsDark: props.backgroundColorIsDark })
 })
 const textClasses = computed(() => {
-  let classes = textColorClasses.value
+  let classes = colorClasses.value
   classes.strikethrough = props.isStrikeThrough
   return classes
 })
@@ -140,7 +140,7 @@ const showTagDetailsIsVisible = (event, tag) => {
 span.name-segment(:data-segment-types="dataMarkdownType" :data-tag-color="dataTagColor" :data-tag-name="dataTagName" :class="nameSegmentClasses")
   template(v-if="props.segment.isText && props.segment.content")
     //- Name markdown
-    span.markdown(v-if="props.segment.markdown" :class="textColorClasses")
+    span.markdown(v-if="props.segment.markdown" :class="colorClasses")
       template(v-for="markdown in props.segment.markdown")
         template(v-if="markdown.type === 'text'")
           span {{smartQuotes(markdown.content)}}

--- a/src/components/OtherSpacePreviewCard.vue
+++ b/src/components/OtherSpacePreviewCard.vue
@@ -57,14 +57,14 @@ const background = computed(() => {
   return utils.alternateColor(color, isThemeDark.value)
 })
 
-const textColorClasses = computed(() => {
+const colorClasses = computed(() => {
   const defaultColor = utils.cssVariable('secondary-background')
   let color
   color = background.value || defaultColor
   if (isThemeDark.value) {
     color = background.value || defaultColor
   }
-  let classes = utils.textColorClasses({ backgroundColor: color })
+  let classes = utils.colorClasses({ backgroundColor: color })
   if (props.isImageCard) {
     classes.push('is-image-card')
   }
@@ -118,7 +118,7 @@ const openUrl = async (event) => {
 </script>
 
 <template lang="pug">
-.other-space-preview-card(:class="textColorClasses")
+.other-space-preview-card(:class="colorClasses")
   //- preview image
   .preview-image-wrap(v-if="previewImageIsVisible")
     img.preview-image(:src="previewImage" :class="{selected: props.isSelected}" ref="image")

--- a/src/components/Preload.vue
+++ b/src/components/Preload.vue
@@ -43,6 +43,7 @@
     img.icon(src="@/assets/checkmark.svg")
     img.icon(src="@/assets/clover.svg")
     img.icon(src="@/assets/comment.svg")
+    img.icon(src="@/assets/connect-items.svg")
     img.icon(src="@/assets/connection-clear.svg")
     img.icon(src="@/assets/connection-path-straight.svg")
     img.icon(src="@/assets/connection-path.svg")

--- a/src/components/SpaceDetailsInfo.vue
+++ b/src/components/SpaceDetailsInfo.vue
@@ -287,7 +287,7 @@ const removeSpaceTeam = () => {
           span {{remotePendingUpload.percentComplete}}%
       BackgroundPicker(:visible="state.backgroundIsVisible" @updateLocalSpaces="updateLocalSpaces")
     //- Name
-    .textarea-wrap(:class="{'full-width': props.shouldHidePin}")
+    .textarea-wrap(:class="{'full-width': props.shouldHidePin, 'space-is-hidden': props.currentSpaceIsHidden}")
       textarea.name(
         :readonly="!isSpaceMember"
         ref="nameElement"
@@ -395,8 +395,6 @@ template(v-if="state.settingsIsVisible")
               span Remove
           //- Hide
           button(@click.stop="toggleHideSpace" :class="{ active: props.currentSpaceIsHidden }")
-            img.icon(v-if="!props.currentSpaceIsHidden" src="@/assets/view.svg")
-            img.icon(v-if="props.currentSpaceIsHidden" src="@/assets/view-hidden.svg")
             span Hide
 </template>
 

--- a/src/components/SpaceList.vue
+++ b/src/components/SpaceList.vue
@@ -599,6 +599,4 @@ span.space-list-wrap
           width 100%
           height 100%
 
-  .space-is-hidden
-    opacity 0.5
 </style>

--- a/src/components/SpaceList.vue
+++ b/src/components/SpaceList.vue
@@ -406,7 +406,7 @@ span.space-list-wrap
         a(:href="space.url")
           li(
             @click.left="selectSpace($event, space)"
-            :class="{ active: spaceIsActive(space), hover: state.focusOnId === space.id }"
+            :class="{ active: spaceIsActive(space), hover: state.focusOnId === space.id, 'space-is-hidden': space.isHidden }"
             tabindex="0"
             @keyup.enter="selectSpace(null, space)"
             :data-created-at="space.createdAt"
@@ -598,4 +598,7 @@ span.space-list-wrap
         .preview-thumbnail-image
           width 100%
           height 100%
+
+  .space-is-hidden
+    opacity 0.5
 </style>

--- a/src/components/TeamInvitePreview.vue
+++ b/src/components/TeamInvitePreview.vue
@@ -79,14 +79,14 @@ const background = computed(() => {
   return utils.alternateColor(color, isThemeDark.value)
 })
 
-const textColorClasses = computed(() => {
+const colorClasses = computed(() => {
   const defaultColor = utils.cssVariable('secondary-background')
   let color
   color = background.value || defaultColor
   if (isThemeDark.value) {
     color = background.value || defaultColor
   }
-  let classes = utils.textColorClasses({ backgroundColor: color })
+  let classes = utils.colorClasses({ backgroundColor: color })
   if (props.isImageCard) {
     classes.push('is-image-card')
   }

--- a/src/components/TeamLabel.vue
+++ b/src/components/TeamLabel.vue
@@ -18,7 +18,7 @@ const shortName = computed(() => {
   return name.charAt(0).toUpperCase()
 })
 const classes = computed(() => {
-  return utils.textColorClasses({ backgroundColor: props.team.color })
+  return utils.colorClasses({ backgroundColor: props.team.color })
 })
 </script>
 

--- a/src/components/TiltResize.vue
+++ b/src/components/TiltResize.vue
@@ -53,6 +53,11 @@ const remove = (action) => {
     store.dispatch('currentCards/removeTilt', { cardIds })
   }
 }
+const colorClass = computed(() => {
+  if (!props.card.backgroundColor) { return }
+  const colorClass = utils.colorClasses({ backgroundColor: props.card.backgroundColor })
+  return [colorClass]
+})
 
 // tilt
 
@@ -90,7 +95,7 @@ const isResizing = computed(() => {
     title="Drag to Resize"
   )
     button.inline-button(tabindex="-1" :class="{hidden: isPresentationMode, active: isResizing}")
-      img.icon(src="@/assets/resize-corner.svg")
+      img.icon(src="@/assets/resize-corner.svg" :class="colorClass")
 //- tilt
 .left-tilt.bottom-button-wrap(v-if="tiltIsVisible")
   .inline-button-wrap(
@@ -100,7 +105,7 @@ const isResizing = computed(() => {
     title="Drag to Tilt"
   )
     button.inline-button(tabindex="-1" :class="{hidden: isPresentationMode, active: isTilting}")
-      img.icon(src="@/assets/resize-corner.svg")
+      img.icon(src="@/assets/resize-corner.svg" :class="colorClass")
 </template>
 
 <style lang="stylus">

--- a/src/components/UrlPreviewCard.vue
+++ b/src/components/UrlPreviewCard.vue
@@ -52,13 +52,13 @@ const background = computed(() => {
   return utils.alternateColor(color, isThemeDark.value)
 })
 const backgroundColorIsDark = computed(() => utils.colorIsDark(background.value))
-const textColorClasses = computed(() => {
+const colorClasses = computed(() => {
   const recomputeOnThemeChange = isThemeDark.value // used to force recompute
   let color = background.value
   if (!color) {
     color = utils.cssVariable('secondary-background')
   }
-  return utils.textColorClasses({ backgroundColor: color })
+  return utils.colorClasses({ backgroundColor: color })
 })
 
 // preview image
@@ -291,9 +291,9 @@ const openUrl = async (event, url) => {
         template(v-if="!props.card.urlPreviewIframeUrl")
           img.favicon(v-if="props.card.urlPreviewFavicon" :src="props.card.urlPreviewFavicon")
           img.icon.favicon.open(v-else src="@/assets/open.svg")
-        .title(:class="textColorClasses")
+        .title(:class="colorClasses")
           span {{title}}
-      .description(v-if="description" :class="textColorClasses")
+      .description(v-if="description" :class="colorClasses")
         span {{description}}
 </template>
 

--- a/src/components/dialogs/BoxDetails.vue
+++ b/src/components/dialogs/BoxDetails.vue
@@ -205,12 +205,15 @@ dialog.narrow.box-details(v-if="visible" :open="visible" @click.left.stop="close
           maxLength="600"
           :class="{'is-dark': colorisDark, 'is-light': !colorisDark}"
         )
-    CardOrBoxActions(:visible="canEditBox" :boxes="[currentBox]" @closeDialogs="closeDialogs" :colorIsHidden="true")
     .row(v-if="canEditBox")
       //- remove
       .button-wrap
         button.danger(@click.left="removeBox")
           img.icon(src="@/assets/remove.svg")
+      //- checkbox
+      .button-wrap
+        button C
+    CardOrBoxActions(:visible="canEditBox" :boxes="[currentBox]" @closeDialogs="closeDialogs" :colorIsHidden="true")
     .row(v-if="!canEditBox")
       span.badge.info
         img.icon(src="@/assets/unlock.svg")

--- a/src/components/dialogs/BoxDetails.vue
+++ b/src/components/dialogs/BoxDetails.vue
@@ -21,7 +21,6 @@ const state = reactive({
   isUpdated: false
 })
 
-const visible = computed(() => utils.objectHasKeys(currentBox.value))
 const spaceCounterZoomDecimal = computed(() => store.getters.spaceCounterZoomDecimal)
 const canEditBox = computed(() => store.getters['currentUser/canEditBox'](currentBox.value))
 
@@ -52,6 +51,17 @@ watch(() => currentBox.value, async (value, prevValue) => {
     store.dispatch('history/add', { boxes: [box], useSnapshot: true })
   }
 })
+
+const visible = computed(() => utils.objectHasKeys(currentBox.value))
+watch(() => visible.value, async (value, prevValue) => {
+  await nextTick()
+  if (!value) {
+    store.commit('currentDraggingBoxId', '')
+    store.dispatch('multipleBoxesSelectedIds', [])
+    store.commit('preventMultipleSelectedActionsIsVisible', false)
+  }
+})
+
 const broadcastShowBoxDetails = () => {
   const updates = {
     boxId: currentBox.value.id,

--- a/src/components/dialogs/BoxDetails.vue
+++ b/src/components/dialogs/BoxDetails.vue
@@ -4,6 +4,7 @@ import { useStore } from 'vuex'
 
 import ColorPicker from '@/components/dialogs/ColorPicker.vue'
 import CardOrBoxActions from '@/components/subsections/CardOrBoxActions.vue'
+import ItemCheckboxButton from '@/components/ItemCheckboxButton.vue'
 import utils from '@/utils.js'
 
 import { colord, extend } from 'colord'
@@ -151,29 +152,6 @@ const removeBox = () => {
   store.dispatch('currentBoxes/remove', currentBox.value)
 }
 
-// checkbox
-
-const checkbox = computed(() => Boolean(utils.checkboxFromString(name.value)))
-const checkboxIsChecked = computed({
-  get () {
-    return utils.nameIsChecked(name.value)
-  },
-  set (value) {
-    if (utils.nameIsChecked(name.value)) {
-      store.dispatch('currentBoxes/removeChecked', currentBox.value.id)
-    } else {
-      store.dispatch('currentBoxes/toggleChecked', { boxId: currentBox.value.id, value })
-    }
-  }
-})
-const addCheckbox = () => {
-  const update = {
-    id: currentBox.value.id,
-    name: `[] ${currentBox.value.name}`
-  }
-  store.dispatch('currentBoxes/update', update)
-}
-
 // dialog state
 
 const closeDialogs = () => {
@@ -234,11 +212,7 @@ dialog.narrow.box-details(v-if="visible" :open="visible" @click.left.stop="close
         button.danger(@click.left="removeBox")
           img.icon(src="@/assets/remove.svg")
       //- [·]
-      .button-wrap.checkbox-button-wrap
-        label.fixed-height(v-if="checkbox" :class="{active: checkboxIsChecked, disabled: !canEditBox}" tabindex="0" title="Checkbox")
-          input(type="checkbox" v-model="checkboxIsChecked" tabindex="-1")
-        label.fixed-height(v-else @click.left.prevent="addCheckbox" @keydown.stop.enter="addCheckbox" :class="{disabled: !canEditBox}" tabindex="0")
-          input.add(type="checkbox" tabindex="-1")
+      ItemCheckboxButton(:boxes="[currentBox]" :isDisabled="!canEditBox")
     CardOrBoxActions(:visible="canEditBox" :boxes="[currentBox]" @closeDialogs="closeDialogs" :colorIsHidden="true")
     .row(v-if="!canEditBox")
       span.badge.info
@@ -261,11 +235,4 @@ dialog.narrow.box-details(v-if="visible" :open="visible" @click.left.stop="close
       color var(--primary-on-light-background)
   .info-row
     align-items flex-start
-  .checkbox-button-wrap
-    label
-      display flex
-      align-items center
-    input
-      margin 0
-      vertical-align -1px
 </style>

--- a/src/components/dialogs/BoxDetails.vue
+++ b/src/components/dialogs/BoxDetails.vue
@@ -151,6 +151,29 @@ const removeBox = () => {
   store.dispatch('currentBoxes/remove', currentBox.value)
 }
 
+// checkbox
+
+const checkbox = computed(() => Boolean(utils.checkboxFromString(name.value)))
+const checkboxIsChecked = computed({
+  get () {
+    return utils.nameIsChecked(name.value)
+  },
+  set (value) {
+    if (utils.nameIsChecked(name.value)) {
+      store.dispatch('currentBoxes/removeChecked', currentBox.value.id)
+    } else {
+      store.dispatch('currentBoxes/toggleChecked', { boxId: currentBox.value.id, value })
+    }
+  }
+})
+const addCheckbox = () => {
+  const update = {
+    id: currentBox.value.id,
+    name: `[] ${currentBox.value.name}`
+  }
+  store.dispatch('currentBoxes/update', update)
+}
+
 // dialog state
 
 const closeDialogs = () => {
@@ -210,9 +233,12 @@ dialog.narrow.box-details(v-if="visible" :open="visible" @click.left.stop="close
       .button-wrap
         button.danger(@click.left="removeBox")
           img.icon(src="@/assets/remove.svg")
-      //- checkbox
-      .button-wrap
-        button C
+      //- [·]
+      .button-wrap.checkbox-button-wrap
+        label.fixed-height(v-if="checkbox" :class="{active: checkboxIsChecked, disabled: !canEditBox}" tabindex="0" title="Checkbox")
+          input(type="checkbox" v-model="checkboxIsChecked" tabindex="-1")
+        label.fixed-height(v-else @click.left.prevent="addCheckbox" @keydown.stop.enter="addCheckbox" :class="{disabled: !canEditBox}" tabindex="0")
+          input.add(type="checkbox" tabindex="-1")
     CardOrBoxActions(:visible="canEditBox" :boxes="[currentBox]" @closeDialogs="closeDialogs" :colorIsHidden="true")
     .row(v-if="!canEditBox")
       span.badge.info
@@ -235,4 +261,11 @@ dialog.narrow.box-details(v-if="visible" :open="visible" @click.left.stop="close
       color var(--primary-on-light-background)
   .info-row
     align-items flex-start
+  .checkbox-button-wrap
+    label
+      display flex
+      align-items center
+    input
+      margin 0
+      vertical-align -1px
 </style>

--- a/src/components/dialogs/CardDetails.vue
+++ b/src/components/dialogs/CardDetails.vue
@@ -1385,7 +1385,7 @@ dialog.card-details(v-if="visible" :open="visible" ref="dialogElement" @click.le
             img.icon.remove(src="@/assets/remove.svg")
             //- span Remove
         //- [·]
-        .button-wrap.cards-checkboxes
+        .button-wrap.checkbox-button-wrap
           label.fixed-height(v-if="checkbox" :class="{active: checkboxIsChecked, disabled: !canEditCard}" tabindex="0" title="Checkbox")
             input(type="checkbox" v-model="checkboxIsChecked" tabindex="-1")
           label.fixed-height(v-else @click.left.prevent="addCheckbox" @keydown.stop.enter="addCheckbox" :class="{disabled: !canEditCard}" tabindex="0")
@@ -1516,7 +1516,7 @@ dialog.card-details(v-if="visible" :open="visible" ref="dialogElement" @click.le
   .edit-message
     button
       margin-top 10px
-  .cards-checkboxes
+  .checkbox-button-wrap
     label
       display flex
       align-items center

--- a/src/components/dialogs/CardDetails.vue
+++ b/src/components/dialogs/CardDetails.vue
@@ -17,6 +17,7 @@ import ShareCard from '@/components/dialogs/ShareCard.vue'
 import OtherCardPreview from '@/components/OtherCardPreview.vue'
 import OtherSpacePreview from '@/components/OtherSpacePreview.vue'
 import TeamInvitePreview from '@/components/TeamInvitePreview.vue'
+import ItemCheckboxButton from '@/components/ItemCheckboxButton.vue'
 import utils from '@/utils.js'
 import consts from '@/consts.js'
 
@@ -490,29 +491,6 @@ const clickName = (event) => {
     updateSpacePickerSearch()
     event.stopPropagation()
   }
-}
-
-// checkbox
-
-const checkbox = computed(() => Boolean(utils.checkboxFromString(name.value)))
-const checkboxIsChecked = computed({
-  get () {
-    return utils.nameIsChecked(name.value)
-  },
-  set (value) {
-    if (utils.nameIsChecked(name.value)) {
-      store.dispatch('currentCards/removeChecked', card.value.id)
-    } else {
-      store.dispatch('currentCards/toggleChecked', { cardId: card.value.id, value })
-    }
-  }
-})
-const addCheckbox = () => {
-  const update = {
-    id: card.value.id,
-    name: `[] ${card.value.name}`
-  }
-  store.dispatch('currentCards/update', { card: update })
 }
 
 // character limit
@@ -1385,11 +1363,7 @@ dialog.card-details(v-if="visible" :open="visible" ref="dialogElement" @click.le
             img.icon.remove(src="@/assets/remove.svg")
             //- span Remove
         //- [·]
-        .button-wrap.checkbox-button-wrap
-          label.fixed-height(v-if="checkbox" :class="{active: checkboxIsChecked, disabled: !canEditCard}" tabindex="0" title="Checkbox")
-            input(type="checkbox" v-model="checkboxIsChecked" tabindex="-1")
-          label.fixed-height(v-else @click.left.prevent="addCheckbox" @keydown.stop.enter="addCheckbox" :class="{disabled: !canEditCard}" tabindex="0")
-            input.add(type="checkbox" tabindex="-1")
+        ItemCheckboxButton(:cards="[card]" :isDisabled="!canEditCard")
         //- Image
         .button-wrap
           button(@click.left.stop="toggleImagePickerIsVisible" :class="{active : state.imagePickerIsVisible}" title="Image")
@@ -1516,13 +1490,6 @@ dialog.card-details(v-if="visible" :open="visible" ref="dialogElement" @click.le
   .edit-message
     button
       margin-top 10px
-  .checkbox-button-wrap
-    label
-      display flex
-      align-items center
-    input
-      margin 0
-      vertical-align -1px
   .badges-row
     display flex
     flex-wrap wrap

--- a/src/components/dialogs/ConnectionDetails.vue
+++ b/src/components/dialogs/ConnectionDetails.vue
@@ -290,7 +290,7 @@ dialog.connection-details.narrow(v-if="visible" :open="visible" :style="styles" 
         img.icon(src="@/assets/remove.svg")
 
     //- label etc.
-    ConnectionActions(:hideType="true" :visible="canEditConnection" :connections="[currentConnection]" @closeDialogs="closeDialogs" :canEditAll="canEditConnection" :backgroundColor="userColor" :label="moreLineOptionsLabel")
+    ConnectionActions(:hideType="true" :visible="canEditConnection" :connections="[currentConnection]" :canEditAll="canEditConnection" :backgroundColor="userColor" :label="moreLineOptionsLabel")
 
     p.edit-message.badge.info(v-if="!canEditConnection")
       template(v-if="spacePrivacyIsOpen")

--- a/src/components/dialogs/ConnectionDetails.vue
+++ b/src/components/dialogs/ConnectionDetails.vue
@@ -4,7 +4,7 @@ import { useStore } from 'vuex'
 
 import ResultsFilter from '@/components/ResultsFilter.vue'
 import ConnectionTypeList from '@/components/ConnectionTypeList.vue'
-import ConnectionDecorators from '@/components/ConnectionDecorators.vue'
+import ConnectionActions from '@/components/subsections/ConnectionActions.vue'
 import ColorPicker from '@/components/dialogs/ColorPicker.vue'
 import utils from '@/utils.js'
 
@@ -289,9 +289,9 @@ dialog.connection-details.narrow(v-if="visible" :open="visible" :style="styles" 
       button.danger(@click.left="removeConnection")
         img.icon(src="@/assets/remove.svg")
 
-    .row(v-if="canEditConnection")
-      //- Arrows or Label
-      ConnectionDecorators(:connections="[currentConnection]")
+    //- label etc.
+    ConnectionActions(:hideType="true" :visible="canEditConnection" :connections="[currentConnection]" @closeDialogs="closeDialogs" :canEditAll="canEditConnection" :backgroundColor="userColor" :label="moreLineOptionsLabel")
+
     p.edit-message.badge.info(v-if="!canEditConnection")
       template(v-if="spacePrivacyIsOpen")
         img.icon.open(src="@/assets/open.svg")

--- a/src/components/dialogs/ConnectionDetails.vue
+++ b/src/components/dialogs/ConnectionDetails.vue
@@ -277,12 +277,18 @@ const focusName = async () => {
 dialog.connection-details.narrow(v-if="visible" :open="visible" :style="styles" @click.left="closeColorPicker" ref="dialogElement")
   section.info-section(:style="{backgroundColor: typeColor}" ref="infoSectionElement")
     .dark-theme-background-layer(v-if="isThemeDarkAndTypeColorLight")
+    //- color, name
     .row
       .button-wrap
         button.change-color(:disabled="!canEditConnection" @click.left.stop="toggleColorPicker" :class="{active: state.colorPickerIsVisible}")
           .current-color(:style="{backgroundColor: typeColor}")
         ColorPicker(:currentColor="typeColor" :visible="state.colorPickerIsVisible" @selectedColor="updateTypeColor")
       input.type-name(:disabled="!canEditConnection" placeholder="Connection Name" v-model="typeName" ref="typeNameElement" @focus="focus" @blur="blur" :class="{'is-dark': typeColorisDark}")
+    .row(v-if="canEditConnection")
+      //- Remove
+      button.danger(@click.left="removeConnection")
+        img.icon(src="@/assets/remove.svg")
+
     .row(v-if="canEditConnection")
       //- Arrows or Label
       ConnectionDecorators(:connections="[currentConnection]")
@@ -299,10 +305,6 @@ dialog.connection-details.narrow(v-if="visible" :open="visible" :style="styles" 
       template(v-else-if="spacePrivacyIsClosed")
         img.icon(src="@/assets/unlock.svg")
         span Read Only
-    .row(v-if="canEditConnection")
-      //- Remove
-      button.danger(@click.left="removeConnection")
-        img.icon(src="@/assets/remove.svg")
   section.results-actions(v-if="canEditConnection" ref="resultsActionsElement")
     //- Use Last Type
     .row.title-row

--- a/src/components/dialogs/MultipleSelectedActions.vue
+++ b/src/components/dialogs/MultipleSelectedActions.vue
@@ -551,7 +551,7 @@ dialog.narrow.multiple-selected-actions(
       .button-wrap.items-checkboxes(:class="{ disabled: !canEditAll.cards && !canEditAll.boxes }" title="Toggle Checkboxes")
         label.fixed-height(v-if="state.itemsHaveCheckboxes" :class="{active: state.itemsCheckboxIsChecked}" tabindex="0")
           input(type="checkbox" v-model="itemCheckboxes" tabindex="-1")
-        label(v-if="!state.itemsHaveCheckboxes" @click.left.prevent="addCheckboxToItems" @keydown.stop.enter="addCheckboxToItems" tabindex="0")
+        label.fixed-height(v-if="!state.itemsHaveCheckboxes" @click.left.prevent="addCheckboxToItems" @keydown.stop.enter="addCheckboxToItems" tabindex="0")
           input.add(type="checkbox" tabindex="-1")
       //- Connect
       button(v-if="multipleCardsIsSelected" :class="{active: state.cardsIsConnected}" @click.left.prevent="toggleConnectCards" @keydown.stop.enter="toggleConnectCards" :disabled="!canEditAll.cards" title="Connect/Disconnect Cards")

--- a/src/components/dialogs/MultipleSelectedActions.vue
+++ b/src/components/dialogs/MultipleSelectedActions.vue
@@ -23,7 +23,7 @@ const state = reactive({
   copyItemsIsVisible: false,
   moveItemsIsVisible: false,
   cardsIsConnected: false,
-  cardsHaveCheckboxes: false,
+  itemsHaveCheckboxes: false,
   itemsCheckboxIsChecked: false,
   shareCardIsVisible: false
 })
@@ -150,6 +150,10 @@ const styles = computed(() => {
   }
 })
 
+// items (cards and boxes)
+
+const items = computed(() => cards.value.concat(boxes.value))
+
 // cards
 
 const moreCardOptionsLabel = computed(() => {
@@ -215,16 +219,15 @@ const itemCheckboxes = computed({
   }
 })
 const checkItemsHaveCheckboxes = () => {
-  const cardsWithCheckboxes = cards.value.filter(card => {
-    if (!card) { return }
-    return utils.checkboxFromString(card.name)
+  const itemsWithCheckboxes = items.value.filter(item => {
+    if (!item) { return }
+    return utils.checkboxFromString(item.name)
   })
-  state.cardsHaveCheckboxes = cardsWithCheckboxes.length === cards.value.length
+  state.itemsHaveCheckboxes = itemsWithCheckboxes.length === items.value.length
 }
 const checkItemsCheckboxIsChecked = () => {
-  const items = cards.value.concat(boxes.value)
-  const itemsChecked = items.filter(item => utils.nameIsChecked(item.name))
-  state.itemsCheckboxIsChecked = itemsChecked.length === items.length
+  const itemsChecked = items.value.filter(item => utils.nameIsChecked(item.name))
+  state.itemsCheckboxIsChecked = itemsChecked.length === items.value.length
 }
 const addCheckboxToCards = async () => {
   let updatedCards = []
@@ -238,7 +241,7 @@ const addCheckboxToCards = async () => {
     }
   })
   store.dispatch('currentCards/updateMultiple', updatedCards)
-  state.cardsHaveCheckboxes = true
+  state.itemsHaveCheckboxes = true
   updateDimensionsAndPaths()
 }
 
@@ -525,9 +528,9 @@ dialog.narrow.multiple-selected-actions(
     .row(v-if="cardOrBoxIsSelected")
       //- [·]
       .button-wrap.items-checkboxes(:class="{ disabled: !canEditAll.cards && !canEditAll.boxes }" title="Toggle Checkboxes")
-        label.fixed-height(v-if="state.cardsHaveCheckboxes" :class="{active: state.itemsCheckboxIsChecked}" tabindex="0")
+        label.fixed-height(v-if="state.itemsHaveCheckboxes" :class="{active: state.itemsCheckboxIsChecked}" tabindex="0")
           input(type="checkbox" v-model="itemCheckboxes" tabindex="-1")
-        label(v-if="!state.cardsHaveCheckboxes" @click.left.prevent="addCheckboxToCards" @keydown.stop.enter="addCheckboxToCards" tabindex="0")
+        label(v-if="!state.itemsHaveCheckboxes" @click.left.prevent="addCheckboxToCards" @keydown.stop.enter="addCheckboxToCards" tabindex="0")
           input.add(type="checkbox" tabindex="-1")
       //- Connect
       button(v-if="multipleCardsIsSelected" :class="{active: state.cardsIsConnected}" @click.left.prevent="toggleConnectCards" @keydown.stop.enter="toggleConnectCards" :disabled="!canEditAll.cards" title="Connect/Disconnect Cards")

--- a/src/components/dialogs/MultipleSelectedActions.vue
+++ b/src/components/dialogs/MultipleSelectedActions.vue
@@ -24,7 +24,7 @@ const state = reactive({
   moveItemsIsVisible: false,
   cardsIsConnected: false,
   cardsHaveCheckboxes: false,
-  cardsCheckboxIsChecked: false,
+  itemsCheckboxIsChecked: false,
   shareCardIsVisible: false
 })
 
@@ -44,8 +44,8 @@ const visible = computed(() => {
 })
 watch(() => visible.value, async (value, prevValue) => {
   if (value) {
-    checkCardsHaveCheckboxes()
-    checkCardsCheckboxIsChecked()
+    checkItemsHaveCheckboxes()
+    checkItemsCheckboxIsChecked()
     await nextTick()
     store.commit('pinchCounterZoomDecimal', utils.pinchCounterZoomDecimal())
     checkIsCardsConnected()
@@ -195,12 +195,12 @@ const updateDimensionsAndPaths = async () => {
 
 // card checkboxes
 
-const cardCheckboxes = computed({
+const itemCheckboxes = computed({
   get () {
-    return state.cardsCheckboxIsChecked
+    return state.itemsCheckboxIsChecked
   },
   set (value) {
-    if (state.cardsCheckboxIsChecked) {
+    if (state.itemsCheckboxIsChecked) {
       cards.value.forEach(card => {
         store.dispatch('currentCards/removeChecked', card.id)
       })
@@ -209,21 +209,22 @@ const cardCheckboxes = computed({
         store.dispatch('currentCards/toggleChecked', { cardId: card.id, value })
       })
     }
-    checkCardsHaveCheckboxes()
-    checkCardsCheckboxIsChecked()
+    checkItemsHaveCheckboxes()
+    checkItemsCheckboxIsChecked()
     updateDimensionsAndPaths()
   }
 })
-const checkCardsHaveCheckboxes = () => {
+const checkItemsHaveCheckboxes = () => {
   const cardsWithCheckboxes = cards.value.filter(card => {
     if (!card) { return }
     return utils.checkboxFromString(card.name)
   })
   state.cardsHaveCheckboxes = cardsWithCheckboxes.length === cards.value.length
 }
-const checkCardsCheckboxIsChecked = () => {
-  const cardsChecked = cards.value.filter(card => utils.nameIsChecked(card.name))
-  state.cardsCheckboxIsChecked = cardsChecked.length === cards.value.length
+const checkItemsCheckboxIsChecked = () => {
+  const items = cards.value.concat(boxes.value)
+  const itemsChecked = items.filter(item => utils.nameIsChecked(item.name))
+  state.itemsCheckboxIsChecked = itemsChecked.length === items.length
 }
 const addCheckboxToCards = async () => {
   let updatedCards = []
@@ -521,11 +522,11 @@ dialog.narrow.multiple-selected-actions(
   .dark-theme-background-layer(v-if="isThemeDarkAndUserColorLight")
   section
     //- Edit Cards
-    .row(v-if="cardsIsSelected")
+    .row(v-if="cardOrBoxIsSelected")
       //- [·]
-      .button-wrap.cards-checkboxes(:class="{ disabled: !canEditAll.cards }" title="Card Checkboxes")
-        label.fixed-height(v-if="state.cardsHaveCheckboxes" :class="{active: state.cardsCheckboxIsChecked}" tabindex="0")
-          input(type="checkbox" v-model="cardCheckboxes" tabindex="-1")
+      .button-wrap.items-checkboxes(:class="{ disabled: !canEditAll.cards && !canEditAll.boxes }" title="Toggle Checkboxes")
+        label.fixed-height(v-if="state.cardsHaveCheckboxes" :class="{active: state.itemsCheckboxIsChecked}" tabindex="0")
+          input(type="checkbox" v-model="itemCheckboxes" tabindex="-1")
         label(v-if="!state.cardsHaveCheckboxes" @click.left.prevent="addCheckboxToCards" @keydown.stop.enter="addCheckboxToCards" tabindex="0")
           input.add(type="checkbox" tabindex="-1")
       //- Connect
@@ -599,7 +600,7 @@ dialog.narrow.multiple-selected-actions(
         border-top-right-radius var(--small-entity-radius)
         border-bottom-right-radius var(--small-entity-radius)
         margin-right 0
-  .cards-checkboxes
+  .items-checkboxes
     input
       margin 0
     vertical-align 1px

--- a/src/components/dialogs/MultipleSelectedActions.vue
+++ b/src/components/dialogs/MultipleSelectedActions.vue
@@ -463,21 +463,20 @@ dialog.narrow.multiple-selected-actions(
 )
   .dark-theme-background-layer(v-if="isThemeDarkAndUserColorLight")
   section
-    //- Edit Cards
-    .row(v-if="cardOrBoxIsSelected")
-      //- [·]
-      ItemCheckboxButton(:boxes="boxes" :cards="cards" :isDisabled="!canEditAll.cards && !canEditAll.boxes")
-      //- Connect
-      button(v-if="multipleCardsIsSelected" :class="{active: state.cardsIsConnected}" @click.left.prevent="toggleConnectCards" @keydown.stop.enter="toggleConnectCards" :disabled="!canEditAll.cards" title="Connect/Disconnect Cards")
-        img.connector-icon.icon(src="@/assets/connector-closed.svg" v-if="state.cardsIsConnected")
-        img.connector-icon.icon(src="@/assets/connector-open.svg" v-else)
-        span Connect
-      //- Share Card
-      //- .button-wrap(v-if="oneCardIsSelected" @click.left.stop="toggleShareCardIsVisible")
-      //-   button(:class="{active: state.shareCardIsVisible}")
-      //-     span Share
-      //-   ShareCard(:visible="state.shareCardIsVisible" :card="cards[0]")
 
+    //- Edit Cards
+    .row
+      //- Remove
+      button.danger(:disabled="!canEditAll.all" @click.left="remove")
+        img.icon(src="@/assets/remove.svg")
+      template(v-if="cardOrBoxIsSelected")
+        //- [·]
+        ItemCheckboxButton(:boxes="boxes" :cards="cards" :isDisabled="!canEditAll.cards && !canEditAll.boxes")
+        //- Connect
+        button(v-if="multipleCardsIsSelected" :class="{active: state.cardsIsConnected}" @click.left.prevent="toggleConnectCards" @keydown.stop.enter="toggleConnectCards" :disabled="!canEditAll.cards" title="Connect/Disconnect Cards")
+          img.connect-items.icon(src="@/assets/connect-items.svg")
+          //- img.connector-icon.icon(src="@/assets/connector-open.svg" v-else)
+          //- span Connect
       //- LINE Options
       .button-wrap(v-if="connectionsIsSelected && !onlyConnectionsIsSelected")
         button(:disabled="!canEditAll.cards && !canEditAll.boxes" @click.left.stop="toggleShouldShowMultipleSelectedLineActions" :class="{active : shouldShowMultipleSelectedLineActions}" title="More Line Options")
@@ -487,28 +486,24 @@ dialog.narrow.multiple-selected-actions(
     CardOrBoxActions(:visible="cardsIsSelected || boxesIsSelected" :cards="cards" :boxes="boxes" @closeDialogs="closeDialogs" :class="{ 'last-row': !connectionsIsSelected }" :backgroundColor="userColor")
     ConnectionActions(:visible="(shouldShowMultipleSelectedLineActions || onlyConnectionsIsSelected) && connectionsIsSelected" :connections="editableConnections" @closeDialogs="closeDialogs" :canEditAll="canEditAll" :backgroundColor="userColor" :label="moreLineOptionsLabel")
 
-  section
-    template(v-if="cardOrBoxIsSelected")
-      .row
-        //- Align And Distribute
-        AlignAndDistribute(:visible="multipleCardOrBoxesIsSelected" :shouldHideMoreOptions="true" :shouldDistributeWithAlign="true" :numberOfSelectedItemsCreatedByCurrentUser="numberOfSelectedItemsCreatedByCurrentUser" :canEditAll="canEditAll" :cards="cards" :editableCards="cards" :connections="connections" :boxes="boxes" :editableBoxes="editableBoxes")
-        //- Move/Copy
-        .segmented-buttons.move-or-copy-wrap
-          button(@click.left.stop="toggleCopyItemsIsVisible" :class="{ active: state.copyItemsIsVisible }")
-            span Copy
-            MoveOrCopyItems(:visible="state.copyItemsIsVisible" :actionIsMove="false")
-          button(@click.left.stop="toggleMoveItemsIsVisible" :class="{ active: state.moveItemsIsVisible }" :disabled="!canEditAll.cards")
-            span Move
-            MoveOrCopyItems(:visible="state.moveItemsIsVisible" :actionIsMove="true")
-      //- More Options
-      AlignAndDistribute(:visible="multipleCardOrBoxesIsSelected && moreOptionsIsVisible" :numberOfSelectedItemsCreatedByCurrentUser="numberOfSelectedItemsCreatedByCurrentUser" :canEditAll="canEditAll" :cards="cards" :editableCards="cards" :connections="connections" :boxes="boxes" :editableBoxes="editableBoxes")
-
+  section(v-if="cardOrBoxIsSelected")
     .row
-      //- Remove
-      button.danger(:disabled="!canEditAll.all" @click.left="remove")
-        img.icon(src="@/assets/remove.svg")
+      //- Align And Distribute
+      AlignAndDistribute(:visible="multipleCardOrBoxesIsSelected" :shouldHideMoreOptions="true" :shouldDistributeWithAlign="true" :numberOfSelectedItemsCreatedByCurrentUser="numberOfSelectedItemsCreatedByCurrentUser" :canEditAll="canEditAll" :cards="cards" :editableCards="cards" :connections="connections" :boxes="boxes" :editableBoxes="editableBoxes")
+      //- Move/Copy
+      .segmented-buttons.move-or-copy-wrap
+        button(@click.left.stop="toggleCopyItemsIsVisible" :class="{ active: state.copyItemsIsVisible }")
+          span Copy
+          MoveOrCopyItems(:visible="state.copyItemsIsVisible" :actionIsMove="false")
+        button(@click.left.stop="toggleMoveItemsIsVisible" :class="{ active: state.moveItemsIsVisible }" :disabled="!canEditAll.cards")
+          span Move
+          MoveOrCopyItems(:visible="state.moveItemsIsVisible" :actionIsMove="true")
+    //- More Options
+    AlignAndDistribute(:visible="multipleCardOrBoxesIsSelected && moreOptionsIsVisible" :numberOfSelectedItemsCreatedByCurrentUser="numberOfSelectedItemsCreatedByCurrentUser" :canEditAll="canEditAll" :cards="cards" :editableCards="cards" :connections="connections" :boxes="boxes" :editableBoxes="editableBoxes")
+
+    .row(v-if="multipleCardsIsSelected")
       //- Merge
-      button(v-if="multipleCardsIsSelected" @click="mergeSelectedCards" :disabled="!canEditAll.cards")
+      button(@click="mergeSelectedCards" :disabled="!canEditAll.cards")
         img.icon(src="@/assets/merge.svg")
         span Merge
       //- Split
@@ -570,4 +565,8 @@ dialog.narrow.multiple-selected-actions(
 
   .segmented-buttons + .segmented-buttons
     margin-left 0
+
+  .icon.connect-items
+    height 12px
+    vertical-align -1px
 </style>

--- a/src/components/dialogs/MultipleSelectedActions.vue
+++ b/src/components/dialogs/MultipleSelectedActions.vue
@@ -197,20 +197,28 @@ const updateDimensionsAndPaths = async () => {
   store.dispatch('currentConnections/updateMultiplePaths', cards.value)
 }
 
-// card checkboxes
+// item checkboxes
 
 const itemCheckboxes = computed({
   get () {
     return state.itemsCheckboxIsChecked
   },
   set (value) {
+    // remove checkbox
     if (state.itemsCheckboxIsChecked) {
       cards.value.forEach(card => {
         store.dispatch('currentCards/removeChecked', card.id)
       })
+      boxes.value.forEach(box => {
+        store.dispatch('currentBoxes/removeChecked', box.id)
+      })
+    // add checkbox
     } else {
       cards.value.forEach(card => {
         store.dispatch('currentCards/toggleChecked', { cardId: card.id, value })
+      })
+      boxes.value.forEach(box => {
+        store.dispatch('currentBoxes/toggleChecked', { boxId: box.id, value })
       })
     }
     checkItemsHaveCheckboxes()
@@ -229,8 +237,10 @@ const checkItemsCheckboxIsChecked = () => {
   const itemsChecked = items.value.filter(item => utils.nameIsChecked(item.name))
   state.itemsCheckboxIsChecked = itemsChecked.length === items.value.length
 }
-const addCheckboxToCards = async () => {
+const addCheckboxToItems = async () => {
   let updatedCards = []
+  let updatedBoxes = []
+  // cards
   cards.value.forEach(card => {
     if (!utils.checkboxFromString(card.name)) {
       const update = {
@@ -241,6 +251,17 @@ const addCheckboxToCards = async () => {
     }
   })
   store.dispatch('currentCards/updateMultiple', updatedCards)
+  // boxes
+  boxes.value.forEach(box => {
+    if (!utils.checkboxFromString(box.name)) {
+      const update = {
+        id: box.id,
+        name: `[] ${box.name}`
+      }
+      updatedBoxes.push(update)
+    }
+  })
+  store.dispatch('currentBoxes/updateMultiple', updatedBoxes)
   state.itemsHaveCheckboxes = true
   updateDimensionsAndPaths()
 }
@@ -530,7 +551,7 @@ dialog.narrow.multiple-selected-actions(
       .button-wrap.items-checkboxes(:class="{ disabled: !canEditAll.cards && !canEditAll.boxes }" title="Toggle Checkboxes")
         label.fixed-height(v-if="state.itemsHaveCheckboxes" :class="{active: state.itemsCheckboxIsChecked}" tabindex="0")
           input(type="checkbox" v-model="itemCheckboxes" tabindex="-1")
-        label(v-if="!state.itemsHaveCheckboxes" @click.left.prevent="addCheckboxToCards" @keydown.stop.enter="addCheckboxToCards" tabindex="0")
+        label(v-if="!state.itemsHaveCheckboxes" @click.left.prevent="addCheckboxToItems" @keydown.stop.enter="addCheckboxToItems" tabindex="0")
           input.add(type="checkbox" tabindex="-1")
       //- Connect
       button(v-if="multipleCardsIsSelected" :class="{active: state.cardsIsConnected}" @click.left.prevent="toggleConnectCards" @keydown.stop.enter="toggleConnectCards" :disabled="!canEditAll.cards" title="Connect/Disconnect Cards")

--- a/src/components/dialogs/SpaceDetails.vue
+++ b/src/components/dialogs/SpaceDetails.vue
@@ -13,7 +13,6 @@ import Loader from '@/components/Loader.vue'
 import debounce from 'lodash-es/debounce'
 import uniqBy from 'lodash-es/uniqBy'
 import dayjs from 'dayjs'
-import sortBy from 'lodash-es/sortBy'
 
 const store = useStore()
 
@@ -246,7 +245,7 @@ const sortByUpdatedAt = (spaces) => {
   return sortedSpaces
 }
 const sortByAlphabetical = (spaces) => {
-  return sortBy(spaces, 'name')
+  return utils.sortItemsAlphabeticallyBy(spaces, 'name')
 }
 const sort = (spaces) => {
   if (isSortByCreatedAt.value) {

--- a/src/components/dialogs/SpaceDetails.vue
+++ b/src/components/dialogs/SpaceDetails.vue
@@ -140,6 +140,8 @@ const filteredSpaces = computed(() => {
   // filter by space type
   if (dialogSpaceFilterByType.value === 'journals') {
     spaces = spaces.filter(space => space.moonPhase)
+  } else if (dialogSpaceFilterByType.value === 'spaces') {
+    spaces = spaces.filter(space => !space.moonPhase)
   }
   // hide by hidden spaces unless filter active
   if (!dialogSpaceFilterShowHidden.value) {

--- a/src/components/dialogs/SpaceDetails.vue
+++ b/src/components/dialogs/SpaceDetails.vue
@@ -141,10 +141,8 @@ const filteredSpaces = computed(() => {
   if (dialogSpaceFilterByType.value === 'journals') {
     spaces = spaces.filter(space => space.moonPhase)
   }
-  // filter by hidden spaces
-  if (dialogSpaceFilterShowHidden.value) {
-    spaces = spaces.filter(space => space.isHidden)
-  } else {
+  // hide by hidden spaces unless filter active
+  if (!dialogSpaceFilterShowHidden.value) {
     spaces = spaces.filter(space => !space.isHidden)
   }
   // filter by user

--- a/src/components/dialogs/SpaceFilters.vue
+++ b/src/components/dialogs/SpaceFilters.vue
@@ -2,8 +2,6 @@
 import { reactive, computed, onMounted, onBeforeUnmount, defineProps, defineEmits, watch, ref, nextTick } from 'vue'
 import { useStore } from 'vuex'
 
-import MoonPhase from '@/components/MoonPhase.vue'
-import moonphase from '@/moonphase.js'
 import UserList from '@/components/UserList.vue'
 import utils from '@/utils.js'
 import TeamList from '@/components/TeamList.vue'
@@ -22,7 +20,6 @@ onMounted(() => {
       clearAllFilters()
     }
   })
-  state.moonPhase = moonphase()
 })
 
 const props = defineProps({
@@ -37,7 +34,6 @@ watch(() => props.visible, (value, prevValue) => {
 })
 
 const state = reactive({
-  moonPhase: {},
   dialogHeight: null
 })
 
@@ -206,9 +202,10 @@ dialog.narrow.space-filters(v-if="props.visible" :open="props.visible" @click.le
       .segmented-buttons
         button(@click="updateFilterByType(null)" :class="{active: filterByTypeAll}" title="Show all spaces")
           span All
+        button(@click="updateFilterByType('spaces')" :class="{active: filterByTypeSpaces}" title="Show normal spaces only")
+          span Spaces
         button(@click="updateFilterByType('journals')" :class="{active: filterByTypeJournals}" title="Show journal spaces only")
-          MoonPhase(:moonPhase="state.moonPhase.name")
-          span Journals Only
+          span Journals
 
     //- sort by
     section.subsection

--- a/src/components/subsections/ConnectionActions.vue
+++ b/src/components/subsections/ConnectionActions.vue
@@ -14,7 +14,8 @@ const props = defineProps({
   connections: Array,
   canEditAll: Object,
   backgroundColor: String,
-  label: String
+  label: String,
+  hideType: Boolean
 })
 const emit = defineEmits(['closeDialogs'])
 const state = reactive({
@@ -73,7 +74,7 @@ section.subsection.connection-actions(v-if="visible")
     span {{label}}
   .row.edit-connection-types
     //- Type Color
-    .button-wrap
+    .button-wrap(v-if="!props.hideType")
       button.change-color(:disabled="!canEditAll.connections" @click.left.stop="toggleMultipleConnectionsPickerVisible" :class="{active: state.multipleConnectionsPickerVisible}")
         .segmented-colors.icon
           template(v-for="type in connectionTypes")

--- a/src/store/currentBoxes.js
+++ b/src/store/currentBoxes.js
@@ -188,6 +188,56 @@ export default {
         name: newName
       })
     },
+    updateMultiple: (context, boxes) => {
+      const spaceId = context.rootState.currentSpace.id
+      let updates = {
+        boxes,
+        spaceId: context.rootState.currentSpace.id
+      }
+      updates.boxes.map(box => {
+        delete box.userId
+        return box
+      })
+      context.dispatch('api/addToQueue', { name: 'updateMultipleBoxes', body: updates }, { root: true })
+      context.dispatch('history/add', { boxes }, { root: true })
+      boxes.forEach(box => {
+        context.dispatch('broadcast/update', { updates: box, type: 'updateBox', handler: 'currentBoxes/update' }, { root: true })
+        context.commit('update', box)
+      })
+      cache.updateSpace('editedByUserId', context.rootState.currentUser.id, currentSpaceId)
+    },
+
+    // checkboxes
+
+    toggleChecked (context, { boxId, value }) {
+      utils.typeCheck({ value, type: 'boolean' })
+      utils.typeCheck({ value: boxId, type: 'string' })
+      const box = context.getters.byId(boxId)
+      let name = box.name
+      const checkbox = utils.checkboxFromString(name)
+      name = name.replace(checkbox, '')
+      if (value) {
+        name = `[x] ${name}`
+      } else {
+        name = `[] ${name}`
+      }
+      const update = {
+        id: boxId,
+        name
+      }
+      context.dispatch('update', update)
+    },
+    removeChecked: (context, boxId) => {
+      utils.typeCheck({ value: boxId, type: 'string' })
+      const box = context.getters.byId(boxId)
+      let name = box.name
+      name = name.replace('[x]', '').trim()
+      const update = {
+        id: boxId,
+        name
+      }
+      context.dispatch('update', update)
+    },
 
     // resize
 

--- a/src/store/currentCards.js
+++ b/src/store/currentCards.js
@@ -362,8 +362,8 @@ const currentCards = {
           context.commit('updateCardNameInOtherItems', card, { root: true })
           context.commit('triggerUpdateOtherCard', card.id, { root: true })
         }
-        cache.updateSpace('editedByUserId', context.rootState.currentUser.id, currentSpaceId)
       })
+      cache.updateSpace('editedByUserId', context.rootState.currentUser.id, currentSpaceId)
     },
     updateCounter: (context, { card, shouldIncrement, shouldDecrement }) => {
       const isSignedIn = context.rootGetters['currentUser/isSignedIn']

--- a/src/store/currentUser.js
+++ b/src/store/currentUser.js
@@ -80,7 +80,7 @@ const initialState = {
 
   // space filters
 
-  dialogSpaceFilterByType: null, // null, journals
+  dialogSpaceFilterByType: null, // null, journals, spaces
   dialogSpaceFilterByTeam: {},
   dialogSpaceFilterByUser: {},
   dialogSpaceFilterShowHidden: false,

--- a/src/utils.js
+++ b/src/utils.js
@@ -865,6 +865,22 @@ export default {
     }
     return rect
   },
+  sortItemsAlphabeticallyBy (items, property) {
+    const sorted = items.sort((a, b) => {
+      // Case-insensitive comparison, ignore emojis
+      let propA = this.normalizeString(a[property]).trim()
+      let propB = this.normalizeString(b[property]).trim()
+      // remove leading dashes
+      propA = this.removeLeadingDashes(propA)
+      propB = this.removeLeadingDashes(propB)
+      if (propA === propB) {
+        // If stripped values are equal, fall back to comparing the original strings
+        return a[property] < b[property] ? -1 : 1
+      }
+      return propA < propB ? -1 : 1
+    })
+    return sorted
+  },
 
   // Cards
 
@@ -1773,6 +1789,10 @@ export default {
   normalizeString (string) {
     // replaces non alphanumeric (spaces, emojis, $%&, etc.) characters with '-'s
     return string.replace(/([^a-z0-9-]+)/ig, '-').toLowerCase()
+  },
+  removeLeadingDashes (string) {
+    // -123-abc -> 123-abc
+    return string.replace(/^-+/, '')
   },
   normalizeFileUrl (string) {
     // same as normalizeString^, but keeps '.' and case

--- a/src/utils.js
+++ b/src/utils.js
@@ -815,7 +815,7 @@ export default {
     }
     return color
   },
-  textColorClasses ({ backgroundColor, backgroundColorIsDark }) {
+  colorClasses ({ backgroundColor, backgroundColorIsDark }) {
     backgroundColorIsDark = backgroundColorIsDark || this.colorIsDark(backgroundColor)
     let classes = []
     if (backgroundColorIsDark) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -219,8 +219,8 @@ export default {
     return {
       x: Math.round(rectPosition.x * zoom),
       y: Math.round(rectPosition.y * zoom),
-      width: Math.round(rect.width * zoom),
-      height: Math.round(rect.height * zoom)
+      width: Math.round(rect.width || rect.resizeWidth * zoom),
+      height: Math.round(rect.height || rect.resizeHeight * zoom)
     }
   },
   isPositionOutsideOfSpace (position) {


### PR DESCRIPTION
- checking off boxes doesn't change the contents of the cards inside
- if a card is contained inside a checked off box it'll be displayed transparent
- the card transparently goes away when the card is selected or being dragged
- checked boxes, and child boxes of checked boxes display transparent

## other

- boxes default to being created with dark colors bc those have the best contrast with cards in both themes
- remove button is first item in all detail views for consistency
- add checkbox icon is blank, removed '+'
- card/box tiltresize icons are visible on dark backgrounds
- improve sorting spaces list alphabetically
- spacefilters: changed behavior of 'hidden' to include hidden spaces in existing list. hidden space names appear transparent in list, name textarea, and in header button