### PR TITLE
Change tile cursor to nwse-resize

### DIFF
--- a/src/components/TiltResize.vue
+++ b/src/components/TiltResize.vue
@@ -147,9 +147,9 @@ const isResizing = computed(() => {
     .inline-button-wrap
       padding-right 0
       transform translate(-8px, 13px)
-      cursor col-resize
+      cursor nwse-resize
       button
-        cursor col-resize
+        cursor nwse-resize
         transform scaleX(-1)
   // resize
   &.right-resize


### PR DESCRIPTION
![QuickTime movie](https://github.com/user-attachments/assets/8b9f10b2-55a2-485f-9d99-383dbb5bd76a)

Someone didn’t know how to rotate cards, finding the current cursor misleading (https://discord.com/channels/857305113936134204/857724442797146173/1293088162222051389).

Maybe this one is slightly better?