### PR TITLE
Shift-Drag Snap to Grid

### DIFF
--- a/src/components/Box.vue
+++ b/src/components/Box.vue
@@ -151,10 +151,6 @@ const styles = computed(() => {
   let { x, y, resizeWidth, resizeHeight } = normalizedBox.value
   let width = resizeWidth
   let height = resizeHeight
-  if (store.state.shouldSnapToGrid && currentBoxIsBeingResized.value) {
-    width = utils.roundToNearest(width)
-    height = utils.roundToNearest(height)
-  }
   let styles = {
     left: x + 'px',
     top: y + 'px',

--- a/src/components/Box.vue
+++ b/src/components/Box.vue
@@ -80,10 +80,9 @@ const normalizedBox = computed(() => {
   return normalizeBox(props.box)
 })
 const normalizeBox = (box) => {
-  const init = 200
   box = utils.clone(box)
-  box.resizeWidth = box.resizeWidth || init
-  box.resizeHeight = box.resizeHeight || init
+  box.resizeWidth = box.resizeWidth || consts.minItemXY
+  box.resizeHeight = box.resizeHeight || consts.minItemXY
   box.width = box.resizeWidth
   box.height = box.resizeHeight
   box.color = box.color || randomColor({ luminosity: 'light' })

--- a/src/components/Box.vue
+++ b/src/components/Box.vue
@@ -171,7 +171,7 @@ const color = computed(() => {
   const remoteColor = remoteBoxDetailsVisibleColor.value || remoteSelectedColor.value || remoteUserResizingBoxesColor.value || remoteBoxDraggingColor.value
   if (remoteColor) {
     return remoteColor
-  } else if (isSelected.value) {
+  } else if (currentBoxIsSelected.value) {
     return userColor.value
   } else {
     return normalizedBox.value.color
@@ -207,15 +207,15 @@ const otherBoxes = computed(() => {
   return boxes.filter(box => box?.id !== props.box.id)
 })
 const snapGuideStyles = computed(() => {
-  if (isDragging.value) {
+  if (currentBoxIsBeingDragged.value) {
     return { background: userColor.value }
   } else {
     return { background: props.box.color }
   }
 })
 const snapGuideSide = computed(() => {
-  const isDragging = store.state.currentUserIsDraggingBox || store.state.currentUserIsDraggingCard
-  if (!isDragging) { return null }
+  const isDraggingItem = store.state.currentUserIsDraggingBox || store.state.currentUserIsDraggingCard
+  if (!isDraggingItem) { return null }
   let guides = store.state.currentBoxes.snapGuides
   const snapGuide = guides.find(guide => {
     const isTarget = guide.target.id === props.box.id
@@ -385,12 +385,12 @@ const canEditSpace = computed(() => store.getters['currentUser/canEditSpace']())
 const shouldJiggle = computed(() => {
   const isMultipleItemsSelected = store.getters.isMultipleItemsSelected
   if (isMultipleItemsSelected) { return }
-  return isDragging.value
+  return currentBoxIsBeingDragged.value
 })
-const isDragging = computed(() => {
+const currentBoxIsBeingDragged = computed(() => {
   const isDragging = store.state.currentUserIsDraggingBox
   const isCurrent = store.state.currentDraggingBoxId === props.box.id
-  return isDragging && (isCurrent || isSelected.value)
+  return isDragging && (isCurrent || currentBoxIsSelected.value)
 })
 const isResizing = computed(() => {
   const isResizing = store.state.currentUserIsResizingBox
@@ -415,7 +415,7 @@ const startBoxInfoInteraction = (event) => {
   selectContainedBoxes()
 }
 const updateIsHover = (value) => {
-  if (isDragging.value) { return }
+  if (store.state.currentUserIsDraggingBox) { return }
   if (isPainting.value) { return }
   state.isHover = value
   if (value) {
@@ -455,10 +455,6 @@ const currentBoxDetailsIsVisible = computed(() => {
 
 // select
 
-const isSelected = computed(() => {
-  const selectedIds = store.state.multipleBoxesSelectedIds
-  return selectedIds.includes(props.box.id)
-})
 const multipleBoxesIsSelected = computed(() => Boolean(store.state.multipleBoxesSelectedIds.length))
 const currentBoxIsSelected = computed(() => {
   const selected = store.state.multipleBoxesSelectedIds
@@ -712,7 +708,7 @@ const updateTouchPosition = (event) => {
 }
 const updateCurrentTouchPosition = (event) => {
   currentTouchPosition = utils.cursorPositionInViewport(event)
-  if (isDragging.value || isResizing.value) {
+  if (currentBoxIsBeingDragged.value || isResizing.value) {
     event.preventDefault() // allows dragging boxes without scrolling
   }
 }
@@ -809,8 +805,8 @@ const toggleBoxChecked = () => {
 const containingBoxes = computed(() => {
   if (!state.isVisibleInViewport) { return }
   if (store.state.currentUserIsDraggingBox) { return }
-  if (isDragging.value) { return }
-  if (isSelected.value) { return }
+  if (currentBoxIsBeingDragged.value) { return }
+  if (currentBoxIsSelected.value) { return }
   if (isResizing.value) { return }
   let boxes = store.getters['currentBoxes/all']
   boxes = boxes.filter(box => {
@@ -844,7 +840,7 @@ const isInCheckedBox = computed(() => {
   :data-should-render="shouldRender"
 
   :style="styles"
-  :class="{hover: state.isHover, active: isDragging, 'box-jiggle': shouldJiggle, 'is-resizing': isResizing, 'is-selected': isSelected, 'is-checked': isChecked || isInCheckedBox}"
+  :class="{hover: state.isHover, active: currentBoxIsBeingDragged, 'box-jiggle': shouldJiggle, 'is-resizing': isResizing, 'is-selected': currentBoxIsSelected, 'is-checked': isChecked || isInCheckedBox}"
   ref="boxElement"
 )
 

--- a/src/components/BoxSnapGuide.vue
+++ b/src/components/BoxSnapGuide.vue
@@ -6,7 +6,6 @@ import utils from '@/utils.js'
 import consts from '@/consts.js'
 const store = useStore()
 
-const boxSnapGuideWaitingDuration = 500
 let waitingAnimationTimer, shouldCancelWaiting, waitingStartTime
 
 const props = defineProps({
@@ -69,14 +68,10 @@ const oppositeSide = (side) => {
   }
 }
 const snapGuideStyles = computed(() => {
-  const offset = 2
+  const offset = 4
   let styles = {}
   let rect = utils.boxElementDimensions({ id: props.box.id })
-  if (currentBoxIsBeingDragged.value) {
-    styles.background = userColor.value
-  } else {
-    styles.background = props.box.color
-  }
+  styles.background = props.box.color
   // left
   if (snapGuideSide.value === 'left') {
     styles.height = rect.height + 'px'
@@ -133,7 +128,7 @@ const waitingAnimationFrame = (timestamp) => {
     return
   }
   const elaspedTime = timestamp - waitingStartTime
-  const percentComplete = (elaspedTime / boxSnapGuideWaitingDuration) // between 0 and 1
+  const percentComplete = (elaspedTime / consts.boxSnapGuideWaitingDuration) // between 0 and 1
   // waiting
   if (percentComplete < 1) {
     state.snapStatus = 'waiting'
@@ -161,7 +156,7 @@ const waitingAnimationFrame = (timestamp) => {
 <style lang="stylus">
 .box-snap-guide
   --snap-guide-width 6px
-  --snap-guide-waiting-duration 0.5s // same as boxSnapGuideWaitingDuration ms
+  --snap-guide-waiting-duration 0.5s // same as consts.boxSnapGuideWaitingDuration ms
   --snap-guide-ready-duration 0.4s
   position absolute
   &.left
@@ -208,25 +203,25 @@ const waitingAnimationFrame = (timestamp) => {
     opacity 0
   100%
     transform translateX(2px)
-    opacity 1
+    opacity 0.9
 @keyframes guideLeftWaiting
   0%
     opacity 0
   100%
     transform translateX(-2px)
-    opacity 1
+    opacity 0.9
 @keyframes guideTopWaiting
   0%
     opacity 0
   100%
     transform translateY(-2px)
-    opacity 1
+    opacity 0.9
 @keyframes guideBottomWaiting
   0%
     opacity 0
   100%
     transform translateY(2px)
-    opacity 1
+    opacity 0.9
 
 // ready animations
 

--- a/src/components/BoxSnapGuide.vue
+++ b/src/components/BoxSnapGuide.vue
@@ -26,19 +26,21 @@ const otherBoxes = computed(() => {
 // styles
 
 const userColor = computed(() => store.state.currentUser.color)
-const snapGuideSide = computed(() => {
-  const isDraggingItem = store.state.currentUserIsDraggingBox || store.state.currentUserIsDraggingCard
-  if (!isDraggingItem) { return null }
+const currentBoxSnapGuide = computed(() => {
   let guides = store.state.currentBoxes.snapGuides
-  const snapGuide = guides.find(guide => {
+  return guides.find(guide => {
     const isTarget = guide.target.id === props.box.id
     const isOrigin = guide.origin.id === props.box.id
     return isTarget || isOrigin
   })
-  if (!snapGuide) { return null }
-  if (snapGuide.target.id === props.box.id) {
+})
+const snapGuideSide = computed(() => {
+  const isDraggingItem = store.state.currentUserIsDraggingBox || store.state.currentUserIsDraggingCard
+  if (!isDraggingItem) { return }
+  const snapGuide = currentBoxSnapGuide.value
+  if (snapGuide?.target.id === props.box.id) {
     return snapGuide.side
-  } else if (snapGuide.origin.id === props.box.id) {
+  } else if (snapGuide?.origin.id === props.box.id) {
     return oppositeSide(snapGuide.side)
   } else {
     return null
@@ -59,6 +61,7 @@ const oppositeSide = (side) => {
   }
 }
 const snapGuideStyles = computed(() => {
+  const offset = 2
   let styles = {}
   let rect = utils.boxElementDimensions({ id: props.box.id })
   if (currentBoxIsBeingDragged.value) {
@@ -69,33 +72,38 @@ const snapGuideStyles = computed(() => {
   // left
   if (snapGuideSide.value === 'left') {
     styles.height = rect.height + 'px'
-    styles.left = (rect.x - 2) + 'px'
+    styles.left = (rect.x - offset) + 'px'
     styles.top = rect.y + 'px'
   // right
   } else if (snapGuideSide.value === 'right') {
     styles.height = rect.height + 'px'
-    styles.left = (rect.x + rect.width - 4) + 'px'
+    styles.left = (rect.x + rect.width - offset) + 'px'
     styles.top = rect.y + 'px'
   // top
   } else if (snapGuideSide.value === 'top') {
     styles.width = rect.width + 'px'
     styles.left = rect.x + 'px'
-    styles.top = (rect.y - 2) + 'px'
+    styles.top = (rect.y - offset) + 'px'
   // bottom
   } else if (snapGuideSide.value === 'bottom') {
     styles.width = rect.width + 'px'
     styles.left = rect.x + 'px'
-    styles.top = (rect.y + rect.height - 4) + 'px'
+    styles.top = (rect.y + rect.height - offset) + 'px'
   }
   return styles
 })
+const isSnapReady = (side) => {
+  const snapGuide = currentBoxSnapGuide.value
+  console.log('🌺', props.box.name, side, snapGuide, snapGuideSide.value)
+  return true
+}
 </script>
 
 <template lang="pug">
-.box-snap-guide.right(v-if="snapGuideSide === 'right'" :style="snapGuideStyles")
-.box-snap-guide.left(v-if="snapGuideSide === 'left'" :style="snapGuideStyles")
-.box-snap-guide.top(v-if="snapGuideSide === 'top'" :style="snapGuideStyles")
-.box-snap-guide.bottom(v-if="snapGuideSide === 'bottom'" :style="snapGuideStyles")
+.box-snap-guide.right(v-if="snapGuideSide === 'right'" :style="snapGuideStyles" :class="{ 'snap-ready': isSnapReady('right') }")
+.box-snap-guide.left(v-if="snapGuideSide === 'left'" :style="snapGuideStyles" :class="{ 'snap-ready': isSnapReady('left') }")
+.box-snap-guide.top(v-if="snapGuideSide === 'top'" :style="snapGuideStyles" :class="{ 'snap-ready': isSnapReady('top') }")
+.box-snap-guide.bottom(v-if="snapGuideSide === 'bottom'" :style="snapGuideStyles" :class="{ 'snap-ready': isSnapReady('bottom') }")
 </template>
 
 <style lang="stylus">
@@ -106,27 +114,31 @@ const snapGuideStyles = computed(() => {
   &.left
     left calc(-1 * var(--snap-guide-width))
     width var(--snap-guide-width)
-    animation guideLeft var(--snap-guide-duration) infinite ease-in-out forwards
     border-top-left-radius var(--entity-radius)
     border-bottom-left-radius var(--entity-radius)
+    &.snap-ready
+      animation guideLeft var(--snap-guide-duration) infinite ease-in-out forwards
   &.right
     right calc(-1 * var(--snap-guide-width))
     width var(--snap-guide-width)
-    animation guideRight var(--snap-guide-duration) infinite ease-in-out forwards
     border-top-right-radius var(--entity-radius)
     border-bottom-right-radius var(--entity-radius)
+    &.snap-ready
+      animation guideRight var(--snap-guide-duration) infinite ease-in-out forwards
   &.top
     top calc(-1 * var(--snap-guide-width))
     height var(--snap-guide-width)
-    animation guideTop var(--snap-guide-duration) infinite ease-in-out forwards
     border-top-left-radius var(--entity-radius)
     border-top-right-radius var(--entity-radius)
+    &.snap-ready
+      animation guideTop var(--snap-guide-duration) infinite ease-in-out forwards
   &.bottom
     bottom calc(-1 * var(--snap-guide-width))
     height var(--snap-guide-width)
-    animation guideBottom var(--snap-guide-duration) infinite ease-in-out forwards
     border-bottom-left-radius var(--entity-radius)
     border-bottom-right-radius var(--entity-radius)
+    &.snap-ready
+      animation guideBottom var(--snap-guide-duration) infinite ease-in-out forwards
 
 @keyframes guideRight
   50%

--- a/src/components/BoxSnapGuide.vue
+++ b/src/components/BoxSnapGuide.vue
@@ -26,38 +26,6 @@ const otherBoxes = computed(() => {
 // styles
 
 const userColor = computed(() => store.state.currentUser.color)
-const snapGuideStyles = computed(() => {
-  let styles = {}
-  let rect = utils.boxRectFromId(props.box.id)
-  rect = utils.rectDimensions(rect)
-  if (currentBoxIsBeingDragged.value) {
-    styles.background = userColor.value
-  } else {
-    styles.background = props.box.color
-  }
-  // left
-  if (snapGuideSide.value === 'left') {
-    styles.height = rect.height + 'px'
-    styles.left = rect.x + 'px'
-    styles.top = rect.y + 'px'
-  // right
-  } else if (snapGuideSide.value === 'right') {
-    styles.height = rect.height + 'px'
-    styles.left = rect.x + rect.width + 'px'
-    styles.top = rect.y + 'px'
-  // top
-  } else if (snapGuideSide.value === 'top') {
-    styles.width = rect.width + 'px'
-    styles.left = rect.x + 'px'
-    styles.top = rect.y + 'px'
-  // bottom
-  } else if (snapGuideSide.value === 'bottom') {
-    styles.width = rect.width + 'px'
-    styles.left = rect.x + 'px'
-    styles.top = rect.y + rect.height + 'px'
-  }
-  return styles
-})
 const snapGuideSide = computed(() => {
   const isDraggingItem = store.state.currentUserIsDraggingBox || store.state.currentUserIsDraggingCard
   if (!isDraggingItem) { return null }
@@ -90,6 +58,38 @@ const oppositeSide = (side) => {
     return 'top'
   }
 }
+const snapGuideStyles = computed(() => {
+  let styles = {}
+  let rect = utils.boxRectFromId(props.box.id)
+  rect = utils.rectDimensions(rect)
+  if (currentBoxIsBeingDragged.value) {
+    styles.background = userColor.value
+  } else {
+    styles.background = props.box.color
+  }
+  // left
+  if (snapGuideSide.value === 'left') {
+    styles.height = rect.height + 'px'
+    styles.left = rect.x + 'px'
+    styles.top = rect.y + 'px'
+  // right
+  } else if (snapGuideSide.value === 'right') {
+    styles.height = rect.height + 'px'
+    styles.left = rect.x + rect.width + 'px'
+    styles.top = rect.y + 'px'
+  // top
+  } else if (snapGuideSide.value === 'top') {
+    styles.width = rect.width + 'px'
+    styles.left = rect.x + 'px'
+    styles.top = rect.y + 'px'
+  // bottom
+  } else if (snapGuideSide.value === 'bottom') {
+    styles.width = rect.width + 'px'
+    styles.left = rect.x + 'px'
+    styles.top = rect.y + rect.height + 'px'
+  }
+  return styles
+})
 </script>
 
 <template lang="pug">

--- a/src/components/BoxSnapGuide.vue
+++ b/src/components/BoxSnapGuide.vue
@@ -1,0 +1,152 @@
+<script setup>
+import { reactive, computed, onMounted, onBeforeUnmount, defineProps, defineEmits, watch, ref, nextTick } from 'vue'
+import { useStore } from 'vuex'
+
+import utils from '@/utils.js'
+const store = useStore()
+
+const props = defineProps({
+  box: Object
+})
+
+const currentBoxIsSelected = computed(() => {
+  const selected = store.state.multipleBoxesSelectedIds
+  return selected.find(id => props.box.id === id)
+})
+const currentBoxIsBeingDragged = computed(() => {
+  const isDragging = store.state.currentUserIsDraggingBox
+  const isCurrent = store.state.currentDraggingBoxId === props.box.id
+  return isDragging && (isCurrent || currentBoxIsSelected.value)
+})
+const otherBoxes = computed(() => {
+  const boxes = store.getters['currentBoxes/isSelectableInViewport']
+  return boxes.filter(box => box?.id !== props.box.id)
+})
+
+// styles
+
+const userColor = computed(() => store.state.currentUser.color)
+const snapGuideStyles = computed(() => {
+  let styles = {}
+  let rect = utils.boxRectFromId(props.box.id)
+  rect = utils.rectDimensions(rect)
+  if (currentBoxIsBeingDragged.value) {
+    styles.background = userColor.value
+  } else {
+    styles.background = props.box.color
+  }
+  // left
+  if (snapGuideSide.value === 'left') {
+    styles.height = rect.height + 'px'
+    styles.left = rect.x + 'px'
+    styles.top = rect.y + 'px'
+  // right
+  } else if (snapGuideSide.value === 'right') {
+    styles.height = rect.height + 'px'
+    styles.left = rect.x + rect.width + 'px'
+    styles.top = rect.y + 'px'
+  // top
+  } else if (snapGuideSide.value === 'top') {
+    styles.width = rect.width + 'px'
+    styles.left = rect.x + 'px'
+    styles.top = rect.y + 'px'
+  // bottom
+  } else if (snapGuideSide.value === 'bottom') {
+    styles.width = rect.width + 'px'
+    styles.left = rect.x + 'px'
+    styles.top = rect.y + rect.height + 'px'
+  }
+  return styles
+})
+const snapGuideSide = computed(() => {
+  const isDraggingItem = store.state.currentUserIsDraggingBox || store.state.currentUserIsDraggingCard
+  if (!isDraggingItem) { return null }
+  let guides = store.state.currentBoxes.snapGuides
+  const snapGuide = guides.find(guide => {
+    const isTarget = guide.target.id === props.box.id
+    const isOrigin = guide.origin.id === props.box.id
+    return isTarget || isOrigin
+  })
+  if (!snapGuide) { return null }
+  if (snapGuide.target.id === props.box.id) {
+    return snapGuide.side
+  } else if (snapGuide.origin.id === props.box.id) {
+    return oppositeSide(snapGuide.side)
+  } else {
+    return null
+  }
+})
+const oppositeSide = (side) => {
+  if (side === 'left') {
+    return 'right'
+  }
+  if (side === 'right') {
+    return 'left'
+  }
+  if (side === 'top') {
+    return 'bottom'
+  }
+  if (side === 'bottom') {
+    return 'top'
+  }
+}
+</script>
+
+<template lang="pug">
+.box-snap-guide.right(v-if="snapGuideSide === 'right'" :style="snapGuideStyles")
+.box-snap-guide.left(v-if="snapGuideSide === 'left'" :style="snapGuideStyles")
+.box-snap-guide.top(v-if="snapGuideSide === 'top'" :style="snapGuideStyles")
+.box-snap-guide.bottom(v-if="snapGuideSide === 'bottom'" :style="snapGuideStyles")
+</template>
+
+<style lang="stylus">
+.box-snap-guide
+  --snap-guide-width 6px
+  --snap-guide-duration 1s
+  position absolute
+  &.left
+    left calc(-1 * var(--snap-guide-width))
+    width var(--snap-guide-width)
+    // top -2px
+    // height calc(100% + 4px)
+    animation guideLeft var(--snap-guide-duration) infinite ease-in-out forwards
+    border-top-left-radius var(--entity-radius)
+    border-bottom-left-radius var(--entity-radius)
+  &.right
+    right calc(-1 * var(--snap-guide-width))
+    width var(--snap-guide-width)
+    // top -2px
+    // height calc(100% + 4px)
+    animation guideRight var(--snap-guide-duration) infinite ease-in-out forwards
+    border-top-right-radius var(--entity-radius)
+    border-bottom-right-radius var(--entity-radius)
+  &.top
+    top calc(-1 * var(--snap-guide-width))
+    height var(--snap-guide-width)
+    // left -2px
+    // width calc(100% + 4px)
+    animation guideTop var(--snap-guide-duration) infinite ease-in-out forwards
+    border-top-left-radius var(--entity-radius)
+    border-top-right-radius var(--entity-radius)
+  &.bottom
+    bottom calc(-1 * var(--snap-guide-width))
+    height var(--snap-guide-width)
+    // left -2px
+    // width calc(100% + 4px)
+    animation guideBottom var(--snap-guide-duration) infinite ease-in-out forwards
+    border-bottom-left-radius var(--entity-radius)
+    border-bottom-right-radius var(--entity-radius)
+
+@keyframes guideRight
+  50%
+    transform translateX(2px)
+@keyframes guideLeft
+  50%
+    transform translateX(-2px)
+@keyframes guideTop
+  50%
+    transform translateY(-2px)
+@keyframes guideBottom
+  50%
+    transform translateY(2px)
+</style>

--- a/src/components/BoxSnapGuide.vue
+++ b/src/components/BoxSnapGuide.vue
@@ -8,11 +8,16 @@ const store = useStore()
 
 let waitingAnimationTimer, shouldCancelWaiting, waitingStartTime
 
+onMounted(() => {
+  updateRect()
+})
+
 const props = defineProps({
   box: Object
 })
 
 const state = reactive({
+  rect: null,
   snapStatus: null // waiting, ready
 })
 
@@ -67,10 +72,13 @@ const oppositeSide = (side) => {
     return 'top'
   }
 }
+const updateRect = () => {
+  state.rect = utils.boxElementDimensions({ id: props.box.id })
+}
 const snapGuideStyles = computed(() => {
   const offset = 4
   let styles = {}
-  let rect = utils.boxElementDimensions({ id: props.box.id })
+  let rect = state.rect
   styles.background = props.box.color
   // left
   if (snapGuideSide.value === 'left') {
@@ -121,7 +129,6 @@ const waitingAnimationFrame = (timestamp) => {
   if (!waitingStartTime) {
     waitingStartTime = timestamp
   }
-
   const snapGuide = currentBoxSnapGuide.value
   if (!snapGuide) {
     cancelWaitingAnimationFrame()
@@ -129,6 +136,7 @@ const waitingAnimationFrame = (timestamp) => {
   }
   const elaspedTime = timestamp - waitingStartTime
   const percentComplete = (elaspedTime / consts.boxSnapGuideWaitingDuration) // between 0 and 1
+  updateRect()
   // waiting
   if (percentComplete < 1) {
     state.snapStatus = 'waiting'
@@ -137,7 +145,7 @@ const waitingAnimationFrame = (timestamp) => {
   } else {
     console.log('🔒🐢 boxSnapGuide waitingAnimationFrame ready')
     state.snapStatus = 'ready'
-    cancelWaitingAnimationFrame()
+    window.requestAnimationFrame(waitingAnimationFrame)
   }
   // cancel
   if (shouldCancelWaiting) {

--- a/src/components/BoxSnapGuide.vue
+++ b/src/components/BoxSnapGuide.vue
@@ -60,8 +60,7 @@ const oppositeSide = (side) => {
 }
 const snapGuideStyles = computed(() => {
   let styles = {}
-  let rect = utils.boxRectFromId(props.box.id)
-  rect = utils.rectDimensions(rect)
+  let rect = utils.boxElementDimensions({ id: props.box.id })
   if (currentBoxIsBeingDragged.value) {
     styles.background = userColor.value
   } else {
@@ -70,23 +69,23 @@ const snapGuideStyles = computed(() => {
   // left
   if (snapGuideSide.value === 'left') {
     styles.height = rect.height + 'px'
-    styles.left = rect.x + 'px'
+    styles.left = (rect.x - 2) + 'px'
     styles.top = rect.y + 'px'
   // right
   } else if (snapGuideSide.value === 'right') {
     styles.height = rect.height + 'px'
-    styles.left = rect.x + rect.width + 'px'
+    styles.left = (rect.x + rect.width - 4) + 'px'
     styles.top = rect.y + 'px'
   // top
   } else if (snapGuideSide.value === 'top') {
     styles.width = rect.width + 'px'
     styles.left = rect.x + 'px'
-    styles.top = rect.y + 'px'
+    styles.top = (rect.y - 2) + 'px'
   // bottom
   } else if (snapGuideSide.value === 'bottom') {
     styles.width = rect.width + 'px'
     styles.left = rect.x + 'px'
-    styles.top = rect.y + rect.height + 'px'
+    styles.top = (rect.y + rect.height - 4) + 'px'
   }
   return styles
 })
@@ -102,37 +101,29 @@ const snapGuideStyles = computed(() => {
 <style lang="stylus">
 .box-snap-guide
   --snap-guide-width 6px
-  --snap-guide-duration 1s
+  --snap-guide-duration 0.2s
   position absolute
   &.left
     left calc(-1 * var(--snap-guide-width))
     width var(--snap-guide-width)
-    // top -2px
-    // height calc(100% + 4px)
     animation guideLeft var(--snap-guide-duration) infinite ease-in-out forwards
     border-top-left-radius var(--entity-radius)
     border-bottom-left-radius var(--entity-radius)
   &.right
     right calc(-1 * var(--snap-guide-width))
     width var(--snap-guide-width)
-    // top -2px
-    // height calc(100% + 4px)
     animation guideRight var(--snap-guide-duration) infinite ease-in-out forwards
     border-top-right-radius var(--entity-radius)
     border-bottom-right-radius var(--entity-radius)
   &.top
     top calc(-1 * var(--snap-guide-width))
     height var(--snap-guide-width)
-    // left -2px
-    // width calc(100% + 4px)
     animation guideTop var(--snap-guide-duration) infinite ease-in-out forwards
     border-top-left-radius var(--entity-radius)
     border-top-right-radius var(--entity-radius)
   &.bottom
     bottom calc(-1 * var(--snap-guide-width))
     height var(--snap-guide-width)
-    // left -2px
-    // width calc(100% + 4px)
     animation guideBottom var(--snap-guide-duration) infinite ease-in-out forwards
     border-bottom-left-radius var(--entity-radius)
     border-bottom-right-radius var(--entity-radius)

--- a/src/components/BoxSnapGuide.vue
+++ b/src/components/BoxSnapGuide.vue
@@ -3,6 +3,7 @@ import { reactive, computed, onMounted, onBeforeUnmount, defineProps, defineEmit
 import { useStore } from 'vuex'
 
 import utils from '@/utils.js'
+import consts from '@/consts.js'
 const store = useStore()
 
 const props = defineProps({
@@ -92,64 +93,108 @@ const snapGuideStyles = computed(() => {
   }
   return styles
 })
-const isSnapReady = (side) => {
+const status = (side) => {
   const snapGuide = currentBoxSnapGuide.value
-  console.log('🌺', props.box.name, side, snapGuide, snapGuideSide.value)
-  return true
+  const timeDelta = Date.now() - snapGuide.time
+  console.log('🌺', props.box.name, side, snapGuide.time, snapGuideSide.value, '💐💐', timeDelta)
+  // TODO rewrite in RAF
+  if (timeDelta <= consts.boxSnapGuideWaitingTime) {
+    return 'waiting'
+  } else {
+    return 'ready'
+  }
 }
 </script>
 
 <template lang="pug">
-.box-snap-guide.right(v-if="snapGuideSide === 'right'" :style="snapGuideStyles" :class="{ 'snap-ready': isSnapReady('right') }")
-.box-snap-guide.left(v-if="snapGuideSide === 'left'" :style="snapGuideStyles" :class="{ 'snap-ready': isSnapReady('left') }")
-.box-snap-guide.top(v-if="snapGuideSide === 'top'" :style="snapGuideStyles" :class="{ 'snap-ready': isSnapReady('top') }")
-.box-snap-guide.bottom(v-if="snapGuideSide === 'bottom'" :style="snapGuideStyles" :class="{ 'snap-ready': isSnapReady('bottom') }")
+.box-snap-guide.right(v-if="snapGuideSide === 'right'" :style="snapGuideStyles" :class="status('right')")
+.box-snap-guide.left(v-if="snapGuideSide === 'left'" :style="snapGuideStyles" :class="status('left')")
+.box-snap-guide.top(v-if="snapGuideSide === 'top'" :style="snapGuideStyles" :class="status('top')")
+.box-snap-guide.bottom(v-if="snapGuideSide === 'bottom'" :style="snapGuideStyles" :class="status('bottom')")
 </template>
 
 <style lang="stylus">
 .box-snap-guide
   --snap-guide-width 6px
-  --snap-guide-duration 0.2s
+  --snap-guide-waiting-duration 0.5s // same as consts.boxSnapGuideWaitingTime
+  --snap-guide-ready-duration 0.2s
   position absolute
   &.left
     left calc(-1 * var(--snap-guide-width))
     width var(--snap-guide-width)
     border-top-left-radius var(--entity-radius)
     border-bottom-left-radius var(--entity-radius)
-    &.snap-ready
-      animation guideLeft var(--snap-guide-duration) infinite ease-in-out forwards
+    &.waiting
+      animation guideLeftWaiting var(--snap-guide-waiting-duration) 1 ease-in-out forwards
+    &.ready
+      animation guideLeftReady var(--snap-guide-ready-duration) infinite ease-in-out forwards
   &.right
     right calc(-1 * var(--snap-guide-width))
     width var(--snap-guide-width)
     border-top-right-radius var(--entity-radius)
     border-bottom-right-radius var(--entity-radius)
-    &.snap-ready
-      animation guideRight var(--snap-guide-duration) infinite ease-in-out forwards
+    &.waiting
+      animation guideRightWaiting var(--snap-guide-waiting-duration) 1 ease-in-out forwards
+    &.ready
+      animation guideRightReady var(--snap-guide-ready-duration) infinite ease-in-out forwards
   &.top
     top calc(-1 * var(--snap-guide-width))
     height var(--snap-guide-width)
     border-top-left-radius var(--entity-radius)
     border-top-right-radius var(--entity-radius)
-    &.snap-ready
-      animation guideTop var(--snap-guide-duration) infinite ease-in-out forwards
+    &.waiting
+      animation guideTopWaiting var(--snap-guide-waiting-duration) 1 ease-in-out forwards
+    &.ready
+      animation guideTopReady var(--snap-guide-ready-duration) infinite ease-in-out forwards
   &.bottom
     bottom calc(-1 * var(--snap-guide-width))
     height var(--snap-guide-width)
     border-bottom-left-radius var(--entity-radius)
     border-bottom-right-radius var(--entity-radius)
-    &.snap-ready
-      animation guideBottom var(--snap-guide-duration) infinite ease-in-out forwards
+    &.waiting
+      animation guideBottomWaiting var(--snap-guide-waiting-duration) 1 ease-in-out forwards
+    &.ready
+      animation guideBottomReady var(--snap-guide-ready-duration) infinite ease-in-out forwards
 
-@keyframes guideRight
+// waiting animations
+
+@keyframes guideRightWaiting
+  0%
+    opacity 0
+  100%
+    transform translateX(2px)
+    opacity 1
+@keyframes guideLeftWaiting
+  0%
+    opacity 0
+  100%
+    transform translateX(-2px)
+    opacity 1
+@keyframes guideTopWaiting
+  0%
+    opacity 0
+  100%
+    transform translateY(-2px)
+    opacity 1
+@keyframes guideBottomWaiting
+  0%
+    opacity 0
+  100%
+    transform translateY(2px)
+    opacity 1
+
+// ready animations
+
+@keyframes guideRightReady
   50%
     transform translateX(2px)
-@keyframes guideLeft
+@keyframes guideLeftReady
   50%
     transform translateX(-2px)
-@keyframes guideTop
+@keyframes guideTopReady
   50%
     transform translateY(-2px)
-@keyframes guideBottom
+@keyframes guideBottomReady
   50%
     transform translateY(2px)
 </style>

--- a/src/components/Boxes.vue
+++ b/src/components/Boxes.vue
@@ -3,6 +3,7 @@ import { reactive, computed, onMounted, onBeforeUnmount, defineProps, defineEmit
 import { useStore } from 'vuex'
 
 import Box from '@/components/Box.vue'
+import BoxSnapGuide from '@/components/BoxSnapGuide.vue'
 const store = useStore()
 
 const isPainting = computed(() => store.state.currentUserIsPainting)
@@ -15,6 +16,7 @@ const spaceZoomDecimal = computed(() => store.getters.spaceZoomDecimal)
   //- locked boxes rendered in ItemsLocked
   template(v-for="box in unlockedBoxes")
     Box(:box="box")
+    BoxSnapGuide(:box="box")
 </template>
 
 <style lang="stylus">

--- a/src/components/Boxes.vue
+++ b/src/components/Boxes.vue
@@ -1,25 +1,21 @@
+<script setup>
+import { reactive, computed, onMounted, onBeforeUnmount, defineProps, defineEmits, watch, ref, nextTick } from 'vue'
+import { useStore } from 'vuex'
+
+import Box from '@/components/Box.vue'
+const store = useStore()
+
+const isPainting = computed(() => store.state.currentUserIsPainting)
+const unlockedBoxes = computed(() => store.getters['currentBoxes/isNotLocked'])
+const spaceZoomDecimal = computed(() => store.getters.spaceZoomDecimal)
+</script>
+
 <template lang="pug">
 .boxes(:class="{unselectable: isPainting}")
   //- locked boxes rendered in ItemsLocked
   template(v-for="box in unlockedBoxes")
     Box(:box="box")
 </template>
-
-<script>
-import Box from '@/components/Box.vue'
-
-export default {
-  name: 'Boxes',
-  components: {
-    Box
-  },
-  computed: {
-    isPainting () { return this.$store.state.currentUserIsPainting },
-    unlockedBoxes () { return this.$store.getters['currentBoxes/isNotLocked'] },
-    spaceZoomDecimal () { return this.$store.getters.spaceZoomDecimal }
-  }
-}
-</script>
 
 <style lang="stylus">
 .boxes

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -465,7 +465,7 @@ const updateStylesWithWidth = (styles) => {
   const cardHasExtendedContent = cardUrlPreviewIsVisible.value || otherCardIsVisible.value || isVisualCard.value || isAudioCard.value
   const cardHasUrlsOrMedia = cardHasMedia.value || cardHasUrls.value
   let cardMaxWidth = resizeWidth.value || props.card.maxWidth || consts.normalCardMaxWidth
-  let cardWidth = resizeWidth.value
+  let cardWidth = resizeWidth.value || cardMaxWidth
   if (store.state.shouldSnapToGrid && currentCardIsBeingResized.value) {
     cardMaxWidth = utils.roundToNearest(cardMaxWidth)
     cardWidth = utils.roundToNearest(cardWidth)

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -465,8 +465,8 @@ const updateStylesWithWidth = (styles) => {
   const cardHasExtendedContent = cardUrlPreviewIsVisible.value || otherCardIsVisible.value || isVisualCard.value || isAudioCard.value
   const cardHasUrlsOrMedia = cardHasMedia.value || cardHasUrls.value
   let cardMaxWidth = resizeWidth.value || props.card.maxWidth || consts.normalCardMaxWidth
-  let cardWidth = resizeWidth.value || cardMaxWidth
-  if (store.state.shouldSnapToGrid && currentCardIsBeingResized.value) {
+  let cardWidth = resizeWidth.value
+  if (store.state.shouldSnapToGrid && currentCardIsBeingResized.value && cardWidth) {
     cardMaxWidth = utils.roundToNearest(cardMaxWidth)
     cardWidth = utils.roundToNearest(cardWidth)
   }

--- a/src/components/Notifications.vue
+++ b/src/components/Notifications.vue
@@ -66,6 +66,7 @@ const closeAllDialogs = () => {
 
 const currentUserIsPaintingLocked = computed(() => store.state.currentUserIsPaintingLocked)
 const currentUserIsResizingCard = computed(() => store.state.currentUserIsResizingCard)
+const currentUserIsResizingBox = computed(() => store.state.currentUserIsResizingBox)
 const currentUserIsTiltingCard = computed(() => store.state.currentUserIsTiltingCard)
 const currentUserIsPanning = computed(() => store.state.currentUserIsPanning)
 const currentUserIsPanningReady = computed(() => store.state.currentUserIsPanningReady)
@@ -333,7 +334,7 @@ aside.notifications(@click.left="closeAllDialogs")
           img.refresh.icon(src="@/assets/refresh.svg")
           span Refresh
 
-  .persistent-item.info(v-if="currentUserIsResizingCard")
+  .persistent-item.info(v-if="currentUserIsResizingCard || currentUserIsResizingBox")
     img.icon.resize(src="@/assets/resize.svg")
     span Drag to Resize
   .persistent-item.info(v-if="currentUserIsTiltingCard")
@@ -349,11 +350,8 @@ aside.notifications(@click.left="closeAllDialogs")
     span Drag to pan
 
   .persistent-item.info(v-if="shouldSnapToGrid")
-    img.icon(src="@/assets/box-select.svg")
-    span Drag to box select
-  .persistent-item.info(v-if="shouldSnapToGrid")
     img.icon(src="@/assets/constrain-axis.svg")
-    span Items snap to grid
+    span Box select, snap to grid
 
   .persistent-item.success(v-if="notifyThanksForDonating")
     p Thank you for being a

--- a/src/components/Notifications.vue
+++ b/src/components/Notifications.vue
@@ -342,15 +342,18 @@ aside.notifications(@click.left="closeAllDialogs")
 
   .persistent-item.info(v-if="currentUserIsPaintingLocked && isTouchDevice")
     img.icon(src="@/assets/brush.svg")
-    span Hold and drag to paint
+    span Drag to paint
 
   .persistent-item.info(v-if="currentUserIsPanningReady || currentUserIsPanning")
     img.icon(src="@/assets/hand.svg")
-    span Hold and drag to pan
+    span Drag to pan
 
   .persistent-item.info(v-if="shouldSnapToGrid")
+    img.icon(src="@/assets/box-select.svg")
+    span Drag to box select
+  .persistent-item.info(v-if="shouldSnapToGrid")
     img.icon(src="@/assets/constrain-axis.svg")
-    span Hold and drag items to snap to grid
+    span Items snap to grid
 
   .persistent-item.success(v-if="notifyThanksForDonating")
     p Thank you for being a

--- a/src/consts.js
+++ b/src/consts.js
@@ -16,6 +16,7 @@ export default {
   normalCardMaxWidth: 200,
   wideCardMaxWidth: 390,
   minCardIframeWidth: 260,
+  boxSnapGuideWaitingTime: 500,
   maxInviteEmailsAllowedToSend: 15,
   defaultConnectionPathCurveControlPoint: 'q90,40',
   defaultTimeout: 40000,

--- a/src/consts.js
+++ b/src/consts.js
@@ -16,6 +16,7 @@ export default {
   normalCardMaxWidth: 200,
   wideCardMaxWidth: 390,
   minCardIframeWidth: 260,
+  boxSnapGuideWaitingDuration: 500,
   maxInviteEmailsAllowedToSend: 15,
   defaultConnectionPathCurveControlPoint: 'q90,40',
   defaultTimeout: 40000,

--- a/src/consts.js
+++ b/src/consts.js
@@ -16,7 +16,6 @@ export default {
   normalCardMaxWidth: 200,
   wideCardMaxWidth: 390,
   minCardIframeWidth: 260,
-  boxSnapGuideWaitingTime: 500,
   maxInviteEmailsAllowedToSend: 15,
   defaultConnectionPathCurveControlPoint: 'q90,40',
   defaultTimeout: 40000,

--- a/src/store/currentBoxes.js
+++ b/src/store/currentBoxes.js
@@ -447,14 +447,16 @@ export default {
 
     // move
 
-    // moveWhileDragging: (context, boxes) => {
-    //   boxes.forEach(box => {
-    //     const element = document.querySelector(`.box[data-box-id="${box.id}"]`)
-    //     element.style.left = box.x + 'px'
-    //     element.style.top = box.y + 'px'
-    //   })
-    //   context.dispatch('currentConnections/updatePathsWhileDragging', { connections }, { root: true })
-    // },
+    moveWhileDragging: (context, { boxes }) => {
+      boxes.forEach(box => {
+        const element = document.querySelector(`.box[data-box-id="${box.id}"]`)
+        if (!element) { return }
+        if (element.dataset.isVisibleInViewport === 'false') { return }
+        element.style.left = box.x + 'px'
+        element.style.top = box.y + 'px'
+        console.log('🤣', element.style.left, box.x, boxes, box)
+      })
+    },
     move: (context, { endCursor, prevCursor, delta }) => {
       const zoom = context.rootGetters.spaceCounterZoomDecimal
       if (!endCursor || !prevCursor) { return }
@@ -526,7 +528,7 @@ export default {
         return box
       })
       // update
-      context.commit('move', { boxes })
+      context.dispatch('moveWhileDragging', { boxes })
       context.commit('boxesWereDragged', true, { root: true })
       context.dispatch('currentConnections/updatePathsWhileDragging', { connections }, { root: true })
       context.dispatch('broadcast/update', { updates: { boxes }, type: 'moveBoxes', handler: 'currentBoxes/moveWhileDraggingBroadcast' }, { root: true })
@@ -590,6 +592,7 @@ export default {
       let boxes = []
       elements.forEach(box => {
         if (box.dataset.isVisibleInViewport === 'false') { return }
+        if (box.dataset.isLocked === 'true') { return }
         boxes.push(box)
       })
       boxes = boxes.map(box => getters.byId(box.dataset.boxId))

--- a/src/store/currentBoxes.js
+++ b/src/store/currentBoxes.js
@@ -289,14 +289,13 @@ export default {
       if (context.rootState.shouldSnapToGrid) { return }
       const snapThreshold = 6
       const spaceEdgeThreshold = 100
-      let targetBoxes = utils.clone(context.getters.all)
+      let targetBoxes = utils.clone(context.getters.isSelectableInViewport)
       let snapGuides = []
       let items
       if (cards) {
         cards = utils.clone(cards)
         cards = [ utils.boundaryRectFromItems(cards) ] // combine multiple selected cards
         items = cards
-        targetBoxes = targetBoxes.filter(box => !box.isLocked)
       } else if (boxes) {
         items = utils.clone(boxes)
       }

--- a/src/store/currentBoxes.js
+++ b/src/store/currentBoxes.js
@@ -308,6 +308,7 @@ export default {
       const snapThreshold = 6
       const spaceEdgeThreshold = 100
       let targetBoxes = utils.clone(context.getters.isSelectableInViewport)
+      const prevSnapGuides = context.state.snapGuides
       let snapGuides = []
       let items
       if (cards) {
@@ -337,6 +338,7 @@ export default {
             min: targetBox.y + snapThreshold,
             max: targetBox.y + targetBox.height - snapThreshold
           })
+          // let time = 1
           // item sides
           const itemLeft = item.x
           const itemRight = item.x + item.width
@@ -353,25 +355,29 @@ export default {
           const isSnapLeftFromItemRight = Math.abs(itemRight - targetBoxLeft) <= snapThreshold
           const isSnapLeftFromItemLeft = Math.abs(itemLeft - targetBoxLeft) <= snapThreshold
           if (!targetBoxIsMinX && isBetweenTargetBoxPointsY && (isSnapLeftFromItemRight || isSnapLeftFromItemLeft)) {
-            snapGuides.push({ side: 'left', origin: item, target: targetBox })
+            const newSnapGuide = context.getters.newSnapGuide({ side: 'left', item, targetBox })
+            snapGuides.push(newSnapGuide)
           }
           // snap right
           const isSnapRightFromItemLeft = Math.abs(itemLeft - targetBoxRight) <= snapThreshold
           const isSnapRightFromItemRight = Math.abs(itemRight - targetBoxRight) <= snapThreshold
           if (isBetweenTargetBoxPointsY && (isSnapRightFromItemLeft || isSnapRightFromItemRight)) {
-            snapGuides.push({ side: 'right', origin: item, target: targetBox })
+            const newSnapGuide = context.getters.newSnapGuide({ side: 'right', item, targetBox })
+            snapGuides.push(newSnapGuide)
           }
           // snap top
           const isSnapTopFromItemBottom = Math.abs(itemBottom - targetBoxTop) <= snapThreshold
           const isSnapTopFromItemTop = Math.abs(itemTop - targetBoxTop) <= snapThreshold
           if (!targetBoxIsMinY && isBetweenTargetBoxPointsX && (isSnapTopFromItemBottom || isSnapTopFromItemTop)) {
-            snapGuides.push({ side: 'top', origin: item, target: targetBox })
+            const newSnapGuide = context.getters.newSnapGuide({ side: 'top', item, targetBox })
+            snapGuides.push(newSnapGuide)
           }
           // snap bottom
           const isSnapBottomFromItemTop = Math.abs(itemTop - targetBoxBottom) <= snapThreshold
           const isSnapBottomFromItemBottom = Math.abs(itemBottom - targetBoxBottom) <= snapThreshold
           if (isBetweenTargetBoxPointsX && (isSnapBottomFromItemTop || isSnapBottomFromItemBottom)) {
-            snapGuides.push({ side: 'bottom', origin: item, target: targetBox })
+            const newSnapGuide = context.getters.newSnapGuide({ side: 'bottom', item, targetBox })
+            snapGuides.push(newSnapGuide)
           }
         })
       })
@@ -633,6 +639,14 @@ export default {
       let colors = boxes.map(box => box.color)
       colors = colors.filter(color => Boolean(color))
       return uniq(colors)
+    },
+    newSnapGuide: (state) => ({ side, item, targetBox }) => {
+      let time = Date.now()
+      const prevGuide = state.snapGuides.find(guide => guide.side === side)
+      if (prevGuide) {
+        time = prevGuide.time
+      }
+      return { side, origin: item, target: targetBox, time }
     }
   }
 }

--- a/src/store/currentBoxes.js
+++ b/src/store/currentBoxes.js
@@ -453,7 +453,6 @@ export default {
         if (element.dataset.isVisibleInViewport === 'false') { return }
         element.style.left = box.x + 'px'
         element.style.top = box.y + 'px'
-        console.log('🤣', element.style.left, box.x, boxes, box)
       })
     },
     move: (context, { endCursor, prevCursor, delta }) => {
@@ -479,6 +478,8 @@ export default {
       let connections = []
       boxes.forEach(box => {
         if (!box) { return }
+        if (!box.x) { box.y = 0 }
+        if (!box.y) { box.y = 0 }
         if (box.x === 0) { delta.x = Math.max(0, delta.x) }
         if (box.y === 0) { delta.y = Math.max(0, delta.y) }
         connections = connections.concat(context.rootGetters['currentConnections/byItemId'](box.id))

--- a/src/store/currentBoxes.js
+++ b/src/store/currentBoxes.js
@@ -256,17 +256,20 @@ export default {
       let connections = []
       let boxes = []
       boxIds.forEach(boxId => {
-        const element = utils.boxElementFromId(boxId)
-        if (!element) { return }
-        let rect = element.getBoundingClientRect()
-        rect = utils.rectDimensions(rect)
+        const rect = utils.boxElementDimensions({ id: boxId })
         let width = rect.width
         let height = rect.height
         width = width + delta.x
         height = height + delta.y
+        if (context.rootState.shouldSnapToGrid) {
+          width = utils.roundToNearest(width)
+          height = utils.roundToNearest(height)
+        }
         const box = { id: boxId, resizeWidth: width, resizeHeight: height }
         boxes.push(box)
         connections = connections.concat(context.rootGetters['currentConnections/byItemId'](box.id))
+        context.commit('currentUserIsResizingBox', true, { root: true })
+        context.commit('currentUserIsResizingBoxIds', [box.id], { root: true })
       })
       context.dispatch('resizeWhileDragging', { boxes })
       context.dispatch('currentConnections/updatePathsWhileDragging', { connections }, { root: true })

--- a/src/store/currentCards.js
+++ b/src/store/currentCards.js
@@ -153,6 +153,8 @@ const currentCards = {
         if (element.dataset.isVisibleInViewport === 'false') { return }
         element.style.left = card.x + 'px'
         element.style.top = card.y + 'px'
+        element.dataset.x = card.x
+        element.dataset.y = card.y
       })
     },
 

--- a/src/store/currentCards.js
+++ b/src/store/currentCards.js
@@ -604,10 +604,6 @@ const currentCards = {
         x: endCursor.x * zoom,
         y: endCursor.y * zoom
       }
-      if (context.rootState.shouldSnapToGrid) {
-        prevCursor = utils.cursorPositionSnapToGrid(prevCursor)
-        endCursor = utils.cursorPositionSnapToGrid(endCursor)
-      }
       delta = delta || {
         x: endCursor.x - prevCursor.x,
         y: endCursor.y - prevCursor.y
@@ -632,7 +628,6 @@ const currentCards = {
         y: prevMoveDelta.y + delta.y
       }
       cards = cards.map(card => {
-        let position
         // x
         const isNoX = card.x === undefined || card.x === null
         if (isNoX) {
@@ -656,6 +651,11 @@ const currentCards = {
           id: card.id,
           width: card.width,
           height: card.height
+        }
+        if (context.rootState.shouldSnapToGrid) {
+          const position = utils.cursorPositionSnapToGrid(card)
+          card.x = position.x
+          card.y = position.y
         }
         utils.updateCardDimensionsDataWhileDragging(card)
         return card
@@ -695,7 +695,7 @@ const currentCards = {
       cards = cards.filter(card => card)
       if (!cards.length) { return }
       cards = cards.map(id => {
-        let card = context.getters.byId(id)
+        let card = utils.cardElementDimensions({ id })
         if (!card) { return }
         card = utils.clone(card)
         if (!card) { return }
@@ -703,15 +703,6 @@ const currentCards = {
         return { id, x, y, z }
       })
       cards = cards.filter(card => Boolean(card))
-      cards = cards.map(card => {
-        card.x = Math.max(card.x + prevMoveDelta.x, 0)
-        card.x = Math.round(card.x)
-        card.y = Math.max(card.y + prevMoveDelta.y, 0)
-        card.y = Math.round(card.y)
-        card.y = Math.max(consts.minItemXY, card.y)
-        card.userId = context.rootState.currentUser.id
-        return card
-      })
       cards = incrementCardsZ(context, cards)
       context.commit('move', { cards, spaceId })
       cards = cards.filter(card => card)

--- a/src/views/Space.vue
+++ b/src/views/Space.vue
@@ -305,7 +305,13 @@ const checkIfShouldSnapBoxes = () => {
   if (!store.state.boxesWereDragged) { return }
   const snapGuides = store.state.currentBoxes.snapGuides
   if (!snapGuides.length) { return }
-  snapGuides.forEach(snapGuide => store.dispatch('currentBoxes/snap', snapGuide))
+
+  snapGuides.forEach(snapGuide => {
+    const elapsedTime = Date.now() - snapGuide.time
+    const shouldSnap = elapsedTime >= consts.boxSnapGuideWaitingDuration
+    if (!shouldSnap) { return }
+    store.dispatch('currentBoxes/snap', snapGuide)
+  })
 }
 const checkIfShouldExpandBoxes = () => {
   if (!store.state.cardsWereDragged) { return }

--- a/src/views/Space.vue
+++ b/src/views/Space.vue
@@ -290,13 +290,14 @@ const stopResizingBoxes = () => {
   store.dispatch('checkIfItemShouldIncreasePageSize', boxes[0])
 }
 const afterResizeBoxes = () => {
-  if (!store.state.shouldSnapToGrid) { return }
   const boxIds = store.state.currentUserIsResizingBoxIds
   const boxes = boxIds.map(boxId => {
-    let { id, resizeWidth, resizeHeight } = store.getters['currentBoxes/byId'](boxId)
-    resizeWidth = utils.roundToNearest(resizeWidth)
-    resizeHeight = utils.roundToNearest(resizeHeight)
-    return { id, resizeWidth, resizeHeight }
+    let { resizeWidth, resizeHeight } = utils.boxElementDimensions({ id: boxId })
+    if (store.state.shouldSnapToGrid) {
+      resizeWidth = utils.roundToNearest(resizeWidth)
+      resizeHeight = utils.roundToNearest(resizeHeight)
+    }
+    return { id: boxId, resizeWidth, resizeHeight }
   })
   store.dispatch('currentBoxes/updateMultiple', boxes)
 }


### PR DESCRIPTION
also, 

- Box dragging performance in spaces w lots of boxes is way faster now
- To prevent accidental box expanding/snapping, you need to hold a card or box near the edge of a box for ~500ms delay before the snap will activate. There are some new box snapping animations to indicate this.
- Shift-drag to snap to grid replaces constrain dragging card to x or y axis, because it's now redundant.
- To drag a box without selecting its contents use option/alt-drag.
- Keyboard Shortcut list has been updated [ss]
