### PR TITLE
Use the color of the first card when merging cards

### DIFF
--- a/src/components/dialogs/MultipleSelectedActions.vue
+++ b/src/components/dialogs/MultipleSelectedActions.vue
@@ -393,6 +393,7 @@ const mergeSelectedCards = () => {
     name: newName,
     x: position.x,
     y: position.y,
+    backgroundColor: cards[0].backgroundColor,
     ...urlPreview
   }
   store.dispatch('currentCards/add', newCard)


### PR DESCRIPTION
This is related to this request: https://forum.kinopio.club/t/merged-card-color/1033/2

That request is asking for setting the color to the user’s default card color. I think this is another viable option.