### PR TITLE
change shrink to use default box size

### DIFF
--- a/src/components/Box.vue
+++ b/src/components/Box.vue
@@ -273,11 +273,12 @@ const resizeColorClass = computed(() => {
 
 // shrink
 
-const shrinkToMinBoxSize = () => {
-  const minBoxSize = consts.minBoxSize
+const shrinkToDefaultBoxSize = () => {
+  const defaultBoxWidth = consts.defaultBoxWidth
+  const defaultBoxHeight = consts.defaultBoxHeight
   let updated = { id: props.box.id }
-  updated.resizeWidth = minBoxSize
-  updated.resizeHeight = minBoxSize
+  updated.resizeWidth = defaultBoxWidth
+  updated.resizeHeight = defaultBoxHeight
   store.dispatch('currentBoxes/update', updated)
 }
 const shrink = () => {
@@ -286,7 +287,7 @@ const shrink = () => {
   prevSelectedBox = null
   const items = cards.concat(boxes)
   if (!items.length) {
-    shrinkToMinBoxSize()
+    shrinkToDefaultBoxSize()
     return
   }
   const rect = utils.boundaryRectFromItems(items)


### PR DESCRIPTION
Current behavior: when you double-click on the lower-right-hand corner of a box to shrink it, and the box has no cards in it, it resizes to the minimum size (70 by 70), which is impractical. That size is intended for when drag-creating a box.

New behavior: double-clicking the box to resize will now shrink it to the default dimensions (if it has no contents).