### PR TITLE
Fix: Copying the box does’t have the same background

### DIFF
--- a/src/store/currentBoxes.js
+++ b/src/store/currentBoxes.js
@@ -194,7 +194,9 @@ export default {
         name: box.name || `Box ${count}`,
         infoHeight: 57,
         infoWidth: 34,
-        headerFontId: context.rootState.currentUser.prevHeaderFontId || 0
+        headerFontId: context.rootState.currentUser.prevHeaderFontId || 0,
+        background: box.background,
+        backgroundIsStretch: box.backgroundIsStretch
       }
       context.dispatch('history/add', { boxes: [box] }, { root: true })
       context.commit('create', box)


### PR DESCRIPTION
This issue fixes the issue mentioned here: https://forum.kinopio.club/t/copying-the-box-doest-have-the-same-background/1543

https://github.com/user-attachments/assets/0ddf1ec1-d50b-4c16-bba1-874f40bed7bc

Instead of adding `background` and `backgroundIsStretch` manually, we could use the spread operator to add all properties that aren't listed in the new box object, but I am not sure if there would be side effects I am not thinking about.


```javascript

box = {
        id: box.id || nanoid(),
        spaceId: currentSpaceId,
        userId: context.rootState.currentUser.id,
        x: box.x,
        y: box.y,
        resizeWidth: box.resizeWidth || minBoxSize,
        resizeHeight: box.resizeHeight || minBoxSize,
        color: box.color || color,
        fill: box.fill || 'filled', // empty, filled
        name: box.name || `Box ${count}`,
        infoHeight: 57,
        infoWidth: 34,
        headerFontId: context.rootState.currentUser.prevHeaderFontId || 0,
        ...box
      }
```