### PR TITLE
fix issues with checkIfShouldNotifySpaceOutOfSync()

### DIFF
--- a/src/components/Notifications.vue
+++ b/src/components/Notifications.vue
@@ -119,14 +119,17 @@ const checkIfShouldNotifySpaceOutOfSync = async () => {
   try {
     if (!currentUserIsSignedIn.value) { return }
     store.commit('isLoadingSpace', true)
-    if (!store.state.currentSpace.updatedAt) { return } // don't check unloaded spaces
+    if (!store.state.currentSpace.updatedAt) {
+      store.commit('isLoadingSpace', false)
+      return
+    } // don't check unloaded spaces
     const remoteSpace = await store.dispatch('api/getSpaceUpdatedAt', { id: store.state.currentSpace.id })
     store.commit('isLoadingSpace', false)
     if (!remoteSpace) { return }
     const space = store.state.currentSpace
     const spaceeditedAt = dayjs(space.editedAt)
     const remoteSpaceeditedAt = dayjs(remoteSpace.editedAt)
-    const deltaMinutes = spaceeditedAt.diff(remoteSpaceeditedAt, 'minute')
+    const deltaMinutes = remoteSpaceeditedAt.diff(spaceeditedAt, 'minute')
     const editedAtIsChanged = deltaMinutes >= 1
     console.info('☎️ checkIfShouldNotifySpaceOutOfSync result', {
       editedAtIsChanged,

--- a/src/store/currentBoxes.js
+++ b/src/store/currentBoxes.js
@@ -244,7 +244,7 @@ export default {
           context.dispatch('currentConnections/updatePaths', { itemId: box.id }, { root: true })
         })
       }
-      await cache.updateSpace('editedAt', utils.unixTime(), currentSpaceId)
+      await context.dispatch('currentSpace/updateSpace', { editedAt: new Date() }, { root: true })
       await context.dispatch('api/addToQueue', { name: 'updateBox', body: box }, { root: true })
     },
     updateName (context, { box, newName }) {

--- a/src/store/currentCards.js
+++ b/src/store/currentCards.js
@@ -249,7 +249,7 @@ export default {
       context.dispatch('currentSpace/checkIfShouldNotifyCardsCreatedIsNearLimit', null, { root: true })
       context.dispatch('userNotifications/addCardUpdated', { cardId: card.id, type: 'createCard' }, { root: true })
       await context.dispatch('api/addToQueue', { name: 'createCard', body: card }, { root: true })
-      await cache.updateSpace('editedAt', utils.unixTime(), currentSpaceId)
+      await context.dispatch('currentSpace/updateSpace', { editedAt: new Date() }, { root: true })
     },
     addMultiple: async (context, { cards, shouldOffsetPosition }) => {
       const spaceId = context.rootState.currentSpace.id
@@ -340,8 +340,10 @@ export default {
         context.commit('updateCardNameInOtherItems', card, { root: true })
         context.commit('triggerUpdateOtherCard', card.id, { root: true })
       }
-      await cache.updateSpace('editedByUserId', context.rootState.currentUser.id, currentSpaceId)
-      await cache.updateSpace('editedAt', utils.unixTime(), currentSpaceId)
+      await context.dispatch('currentSpace/updateSpace', {
+        editedByUserId: context.rootState.currentUser.id,
+        editedAt: new Date()
+      }, { root: true })
       if (!shouldPreventUpdateDimensionsAndPaths) {
         context.commit('triggerUpdateCardDimensionsAndPaths', card.id, { root: true })
       }


### PR DESCRIPTION
There were some issues in `checkIfShouldNotifySpaceOutOfSync()`.

1. `isLoadingSpace` wasn't correctly reset in some cases, which could prevent the method from being executed at all.
2. `editedAt` was missing in the response of `GET /space/updated-at/{spaceId}`
3. The comparison between the 2 dates was flipped around so that `editedAtIsChanged` didn't properly get set to true, except when there were changes on the client.

These 3 changes already improve the behavior of the notification, but I still see 2 issues and need your input.

The local `store.state.currentSpace.editedAt` does not seem to get updated when the user makes a change, like creating or editing a card. This means the local `editedAt` date will always be the last fetched remote `editedAt`. So if the user makes some changes to their space and then switches browser tabs, the notification will be shown because the local `editedAt` didn't update while the remote `editedAt` did.

The same is true when a user A collaborates with another user B in the same space. Once user A stops editing while user B continues to create/edit cards in the space, user A's local `editedAt` will get stale. When user A switches tabs or returns to the window, they will be prompted with the notification as well.

I can see that some local operations, like creating and editing a card update `editedAt` in the cache. But those changes don't seem to be propagated to `store.state.currentSpace`, causing `editedAt` to get stale.

A solution could be to update `store.state.currentSpace` when the user edits the space. I am not sure if this is intended behavior, though.