### PR TITLE
round devicePixelRatio in ImageOrVideo to prevent floating point issues

### DIFF
--- a/src/components/ImageOrVideo.vue
+++ b/src/components/ImageOrVideo.vue
@@ -179,7 +179,7 @@ const imgproxyUrl = (imageURL, width, height) => {
     return props.pendingUploadDataUrl
   }
   const containerBreakpoints = [400, 600, 800, 1200]
-  const devicePixelRatio = Math.round(window.devicePixelRatio ?? 1)
+  const devicePixelRatio = Math.round(window.devicePixelRatio || 1)
   const maxDimensions = Math.max(width, height)
   for (const breakpoint of containerBreakpoints) {
     if (maxDimensions <= breakpoint) {


### PR DESCRIPTION
The reason why images were not showing correctly for some user was that `window.devicePixelRatio` can be a floating point number. I assumed it would always be an integer like 1 or 2, but as Tony showed me it can also be a value like `1.6506249904632568` which then results in URLs like https://img.kinopio.club/_/rs:fit:660.2499961853027:660.2499961853027:0/f:webp/plain/https://cdn.kinopio.club/slh1NcgyD8FkliBDeXgpS/image.png which imgproxy can't process.

We fix this by using `Math.round` to get an integer from `window.devicePixelRatio`