### PR TITLE
change loading behaviour to synchronous

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta name="fragment" content="!">
 
     <!-- mobile -->
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1 minimum-scale=0.2, maximum-scale=3.0, user-scalable=yes">
     <meta name="apple-mobile-web-app-title" content="Kinopio">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">

--- a/src/components/layers/DrawingCanvas.vue
+++ b/src/components/layers/DrawingCanvas.vue
@@ -67,7 +67,6 @@ onMounted(() => {
       } else if (name === 'triggerDrawingInitialize') {
         // perf: save spaceStore.drawingStrokes to var, and clear state
         spaceStrokes = utils.clone(spaceStore.drawingStrokes)
-        spaceStrokes.reverse()
         spaceStore.drawingStrokes = []
         redrawStrokes()
         await updateDrawingDataUrl()

--- a/src/stores/useSpaceStore.js
+++ b/src/stores/useSpaceStore.js
@@ -430,13 +430,11 @@ export const useSpaceStore = defineStore('space', {
       space = utils.normalizeSpace(cachedSpace)
       globalStore.resetStateMeta()
       globalStore.resetPageSizes()
-      // load local space while fetching remote space
+      // restore local space, and then fetch and restore remote space
       try {
-        const [localData, remoteData] = await Promise.all([
-          this.restoreSpaceLocal(space),
-          this.loadRemoteSpace(space)
-        ])
+        await this.restoreSpaceLocal(space)
         // restore remote space
+        const remoteData = await this.loadRemoteSpace(space)
         const remoteSpace = remoteData
         console.info('🎑 remoteSpace', remoteSpace)
         if (!remoteSpace) { return }


### PR DESCRIPTION
to fix race condition in slow computers that will complete fetch before completing local space load

Makes the loading less smart to avoid issues w slower computers that could theoretically complete fetching remote server data Before completing loading/drawing cached/local space