### PR TITLE
Backup queue

### DIFF
--- a/src/cache.js
+++ b/src/cache.js
@@ -395,19 +395,18 @@ export default {
     await idb.update('queue', (value) => [])
   },
 
-  // API Sending in Progress Queue
-  // queue items are moved here at api.sendQueue
+  // Backup API queue
 
-  // async sendingQueue () {
-  //   const queue = await this.getLocal('sendingQueue')
-  //   return queue || []
-  // },
-  // async saveSendingQueue (queue) {
-  //   await this.saveLocal('sendingQueue', queue)
-  // },
-  // async clearSendingQueue () {
-  //   await this.saveLocal('sendingQueue', [])
-  // },
+  async queueBackup () {
+    const queue = await this.getLocal('queueBackup')
+    return queue || []
+  },
+  async saveQueueBackup (queue) {
+    await this.saveLocal('queueBackup', queue)
+  },
+  async clearQueueBackup () {
+    await this.saveLocal('queueBackup', [])
+  },
 
   // Invited Spaces
 

--- a/src/stores/useApiStore.js
+++ b/src/stores/useApiStore.js
@@ -145,7 +145,7 @@ export const useApiStore = defineStore('api', {
 
     // Add and Send Queue Operations
 
-    async sendQueue () {
+    sendQueue: debounce(async function () {
       const userStore = useUserStore()
       const spaceStore = useSpaceStore()
       const globalStore = useGlobalStore()
@@ -183,10 +183,6 @@ export const useApiStore = defineStore('api', {
         globalStore.clearSendingQueue()
         cache.clearQueueBackup()
       }
-    },
-
-    debouncedSendQueue: debounce(function () {
-      this.sendQueue()
     }, 500),
 
     async addToQueue ({ name, body, spaceId }) {
@@ -232,8 +228,8 @@ export const useApiStore = defineStore('api', {
       }
       sessionQueue = newQueue
       cache.saveQueueBackup(sessionQueue)
-      // trigger sending after wait
-      this.debouncedSendQueue()
+      // send to API after debounce period
+      this.sendQueue()
     },
 
     // Meta

--- a/src/stores/useApiStore.js
+++ b/src/stores/useApiStore.js
@@ -169,7 +169,6 @@ export const useApiStore = defineStore('api', {
         response = await fetch(`${consts.apiHost()}/operations`, options)
         if (response.ok) {
           console.info('🛬 operations ok', queue)
-          globalStore.clearSendingQueue()
         } else {
           throw response.statusText
         }


### PR DESCRIPTION
create cache.queuebackup that isn't cleared when sending starts , the way cache.queue is

queuebackup is cleared when queue completes
if page refreshes before queue completes, sessionstore is restored from backupqueue and tries to send it 