### PR TITLE
App api key

### DIFF
--- a/src/components/dialogs/UserAPIInfo.vue
+++ b/src/components/dialogs/UserAPIInfo.vue
@@ -6,6 +6,7 @@ import { useUserStore } from '@/stores/useUserStore'
 import { useSpaceStore } from '@/stores/useSpaceStore'
 
 import utils from '@/utils.js'
+import Loader from '@/components/Loader.vue'
 
 const globalStore = useGlobalStore()
 const userStore = useUserStore()
@@ -25,8 +26,9 @@ const props = defineProps({
   visible: Boolean
 })
 const state = reactive({
-  dialogHeight: null
-  // : false
+  dialogHeight: null,
+  regenInfoIsVisible: false,
+  isLoading: false
 })
 
 watch(() => props.visible, (value, prevValue) => {
@@ -50,12 +52,12 @@ const censor = (value) => {
   const censored = toСensor.replace(/[^-]/g, 'x') // replace every character that isn't `-`
   return censored + uncensored
 }
-const censoredAppApiKey = computed(() => censor(userStore.apiKey))
+const censoredAppApiKey = computed(() => censor(userStore.apiKey)) // TODO use appApiKey
 
 const copy = async (event, type) => {
   globalStore.clearNotificationsWithPosition()
   const position = utils.cursorPositionInPage(event)
-  const apiKey = userStore.apiKey
+  const apiKey = userStore.apiKey // TODO use appApiKey
   let text = userId.value
   if (type === 'apiKey') {
     text = apiKey
@@ -69,13 +71,32 @@ const copy = async (event, type) => {
     globalStore.addNotificationWithPosition({ message: 'Copy Error', position, type: 'danger', layer: 'app', icon: 'cancel' })
   }
 }
+
+// refresh key
+
+const toggleRegenInfoIsVisible = () => {
+  state.regenInfoIsVisible = !state.regenInfoIsVisible
+}
+const refreshAppApiKey = () => {
+  try {
+    state.isLoading = true
+    state.isError = false
+    state.regenInfoIsVisible = false
+    console.log('🐢🐢🐢🐢 TODO fetch here')
+  } catch (error) {
+    console.error('🚒 refreshAppApiKey', error)
+    state.isError = true
+  }
+  // state.isLoading = false
+}
+
 </script>
 
 <template lang="pug">
 dialog.narrow.user-developer-info(v-if="props.visible" :open="props.visible" @click.left.stop ref="dialogElement" :style="{'max-height': state.dialogHeight + 'px'}")
   section.title-section
     .row.title-row
-      span API
+      span API Access
       .button-wrap
         a(href="https://help.kinopio.club/api")
           button.small-button
@@ -97,25 +118,46 @@ dialog.narrow.user-developer-info(v-if="props.visible" :open="props.visible" @cl
     .row.title-row
       span
         img.icon.key(src="@/assets/key.svg")
-        span API Key
-      button.small-button
+        span App API Key
+      button.small-button(@click="toggleRegenInfoIsVisible" :class="{ active: state.regenInfoIsVisible }" title="Regenerate Key")
         img.icon.refresh(src="@/assets/refresh.svg")
-        span Regenerate
-    .row
-      code.badge.secondary {{ censoredAppApiKey }}
-    .row
-      .badge.danger.copy-api-keys
+
+    //- regenerate info
+    .row(v-if="state.regenInfoIsVisible")
+      .badge.danger.api-keys-info
         .row
-          button(@click.left="copy($event, 'apiKey')")
+          button(@click="refreshAppApiKey" :disabled="state.isLoading")
+            img.icon.refresh(src="@/assets/refresh.svg")
+            span Regenerate Key
+        .row
+          span This will disconnect your Kinopio account from any third party apps.
+    //- key and loader
+    .row
+      code.badge.secondary
+        template(v-if="state.isLoading")
+          Loader(:visible="true")
+          span Regenerating Key…
+        template(v-else)
+          span {{ censoredAppApiKey }}
+    //- error handling
+    .badge.danger(v-if="state.isError")
+      span something went wrong
+    //- copy key info
+    .row
+      .badge.danger.api-keys-info
+        .row
+          button(@click.left="copy($event, 'apiKey')" :disabled="state.isLoading")
             img.icon.copy(src="@/assets/copy.svg")
-            span Copy API Key
+            span Copy Key
         p Anyone with your key can read, edit, and remove your cards and spaces. So keep it private.
 </template>
 
 <style lang="stylus">
 dialog.user-developer-info
   overflow auto
-  .copy-api-keys
+  .api-keys-info
     padding-top 4px
     padding-bottom 4px
+  .loader
+    vertical-align -2px
 </style>

--- a/src/components/dialogs/UserAPIInfo.vue
+++ b/src/components/dialogs/UserAPIInfo.vue
@@ -43,6 +43,15 @@ const updateDialogHeight = async () => {
 }
 
 const userId = computed(() => userStore.id)
+const censor = (value) => {
+  const uncensoredCharacters = 5
+  const uncensored = value.slice(-uncensoredCharacters)
+  const toСensor = value.slice(0, -uncensoredCharacters)
+  const censored = toСensor.replace(/[^-]/g, 'x') // replace every character that isn't `-`
+  return censored + uncensored
+}
+const censoredAppApiKey = computed(() => censor(userStore.apiKey))
+
 const copy = async (event, type) => {
   globalStore.clearNotificationsWithPosition()
   const position = utils.cursorPositionInPage(event)
@@ -75,23 +84,28 @@ dialog.narrow.user-developer-info(v-if="props.visible" :open="props.visible" @cl
 
   //- user id
   section
-    p User Id
+    span User Id
     .row
       code.badge.secondary {{ userId }}
     .row
-      .button-wrap
-        button(@click.left="copy($event, 'userId')")
-          img.icon.copy(src="@/assets/copy.svg")
-          span Copy UserId
+      button(@click.left="copy($event, 'userId')")
+        img.icon.copy(src="@/assets/copy.svg")
+        span Copy UserId
+
   //- api key
   section
-    .row
-      p
+    .row.title-row
+      span
         img.icon.key(src="@/assets/key.svg")
         span API Key
+      button.small-button
+        img.icon.refresh(src="@/assets/refresh.svg")
+        span Regenerate
+    .row
+      code.badge.secondary {{ censoredAppApiKey }}
     .row
       .badge.danger.copy-api-keys
-        .button-wrap
+        .row
           button(@click.left="copy($event, 'apiKey')")
             img.icon.copy(src="@/assets/copy.svg")
             span Copy API Key

--- a/src/components/dialogs/UserAPIInfo.vue
+++ b/src/components/dialogs/UserAPIInfo.vue
@@ -66,7 +66,7 @@ const copy = async (event, type) => {
 dialog.narrow.user-developer-info(v-if="props.visible" :open="props.visible" @click.left.stop ref="dialogElement" :style="{'max-height': state.dialogHeight + 'px'}")
   section.title-section
     .row.title-row
-      span Developer
+      span API
       .button-wrap
         a(href="https://help.kinopio.club/api")
           button.small-button

--- a/src/components/subsections/UserSettingsGeneral.vue
+++ b/src/components/subsections/UserSettingsGeneral.vue
@@ -8,7 +8,7 @@ import { useApiStore } from '@/stores/useApiStore'
 
 import UserBillingSettings from '@/components/dialogs/UserBillingSettings.vue'
 import UserAccountSettings from '@/components/dialogs/UserAccountSettings.vue'
-import UserDeveloperInfo from '@/components/dialogs/UserDeveloperInfo.vue'
+import UserAPIInfo from '@/components/dialogs/UserAPIInfo.vue'
 import NotificationSettings from '@/components/dialogs/NotificationSettings.vue'
 import ThemeSettings from '@/components/dialogs/ThemeSettings.vue'
 import ThemeToggle from '@/components/ThemeToggle.vue'
@@ -55,7 +55,7 @@ const state = reactive({
   userBillingSettingsIsVisible: false,
   userAccountSettingsIsVisible: false,
   deleteAllConfirmationVisible: false,
-  userDeveloperInfoIsVisible: false,
+  userAPIInfoIsVisible: false,
   moderatorActionsSettingsIsVisible: false,
   loading: {
     deleteUserPermanent: false
@@ -71,7 +71,7 @@ const closeDialogs = () => {
   state.userAccountSettingsIsVisible = false
   state.notificationSettingsIsVisible = false
   state.themeSettingsIsVisible = false
-  state.userDeveloperInfoIsVisible = false
+  state.userAPIInfoIsVisible = false
   state.moderatorActionsSettingsIsVisible = false
 }
 
@@ -107,11 +107,11 @@ const toggleThemeSettingsIsVisible = () => {
   closeConfirmations()
   state.themeSettingsIsVisible = !isVisible
 }
-const toggleUserDeveloperInfoIsVisible = () => {
-  const isVisible = state.userDeveloperInfoIsVisible
+const toggleUserAPIInfoIsVisible = () => {
+  const isVisible = state.userAPIInfoIsVisible
   closeDialogs()
   closeConfirmations()
-  state.userDeveloperInfoIsVisible = !isVisible
+  state.userAPIInfoIsVisible = !isVisible
 }
 const toggleModeratorActionsSettingsIsVisible = () => {
   const isVisible = state.moderatorActionsSettingsIsVisible
@@ -167,12 +167,12 @@ const deleteUserPermanent = async () => {
           span(v-else) Billing
         UserBillingSettings(:visible="state.userBillingSettingsIsVisible")
     .row
-      //- Developer Info
+      //- API/Developer Info
       .button-wrap
-        button(@click.left.stop="toggleUserDeveloperInfoIsVisible" :class="{active: state.userDeveloperInfoIsVisible}")
+        button(@click.left.stop="toggleUserAPIInfoIsVisible" :class="{active: state.userAPIInfoIsVisible}")
           img.icon.key(src="@/assets/key.svg")
-          span Developer
-        UserDeveloperInfo(:visible="state.userDeveloperInfoIsVisible")
+          span API
+        UserAPIInfo(:visible="state.userAPIInfoIsVisible")
       //- Moderator Actions
       .button-wrap(v-if="isModerator")
         button(@click.left.stop="toggleModeratorActionsSettingsIsVisible" :class="{active: state.moderatorActionsSettingsIsVisible}")


### PR DESCRIPTION
was partway through adding a seperate 'app api key' that could be rengerated based on an earlier request, but re-reading the request it seemed like i'd just have to end up doing the hard version later (adding the ability to create/regen application specific read or write api keys). So abandoned the easy path and ported some small ui updates and renamed the settings dialog from 'developer info' to 'api' instead for now. 


keeping this here as a temporary record