### PR TITLE
About page roi section

### DIFF
--- a/src/components/page/about/AboutTeamBenefits.vue
+++ b/src/components/page/about/AboutTeamBenefits.vue
@@ -1,0 +1,26 @@
+<script setup>
+import { reactive, computed, onMounted, onBeforeUnmount, watch, ref, nextTick } from 'vue'
+</script>
+
+<template lang="pug">
+//- todo table grid layout
+section.team-benefits
+  video(
+    autoplay
+    loop
+    muted
+    playsinline
+    poster="https://updates.kinopio.club/page/about/hero/1.webp"
+    aria-label="Kinopio collaboration in action."
+    width="715"
+    height="511"
+  )
+    source(src="https://cdn.kinopio.club/8wV0-FJ4jGhuj4j84Ub6n/qCqw4D5OqarHGTLe.mp4")
+  p Also made for teams
+  p More effective meetings, better alignment. Reduce time in meetings. Get projects started faster. Build things more effectively/efficiently together
+
+</template>
+
+<style lang="stylus">
+// section.team-benefits
+</style>

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -10,6 +10,7 @@ import Wordmark from '@/components/page/Wordmark.vue'
 import Header from '@/components/page/Header.vue'
 import AboutSocialProof from '@/components/page/about/AboutSocialProof.vue'
 import AboutHowTo from '@/components/page/about/AboutHowTo.vue'
+import AboutTeamBenefits from '@/components/page/about/AboutTeamBenefits.vue'
 import AboutExamples from '@/components/page/about/AboutExamples.vue'
 import AboutMoreFeatures from '@/components/page/about/AboutMoreFeatures.vue'
 import AboutCollaborate from '@/components/page/about/AboutCollaborate.vue'
@@ -92,6 +93,8 @@ AboutJsonLd
         .button-wrap
           router-link(to="/app")
             button.success Open Kinopio
+
+      AboutTeamBenefits
 
       AboutHowTo
 

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -87,8 +87,8 @@ AboutJsonLd
         p Kinopio is a note-taking canvas for collecting and connecting your thoughts, ideas, and plans by yourself or collaboratively. Community-funded and{{' '}}
           a(href="https://pketh.org/organic-software.html") built for the long-term
           span .
-        p Free for 100 cards. No sign up required.
 
+        p Free for 100 cards. No sign up required.
         //- cta
         .button-wrap
           router-link(to="/app")

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -84,7 +84,7 @@ AboutJsonLd
           height="511"
         )
           source(src="https://updates.kinopio.club/page/about/hero/1.webm")
-        p Kinopio is a note-taking canvas for collecting and connecting your thoughts, ideas, and plans by yourself or collaboratively. Community-funded and{{' '}}
+        p Kinopio is a note-taking canvas for collecting and connecting your thoughts, ideas, and plans by yourself or collaboratively. Started in 2018, community-funded, and{{' '}}
           a(href="https://pketh.org/organic-software.html") built for the long-term
           span .
 


### PR DESCRIPTION
create roi team benefits at a glance section on about page, other copy tweaks. 
in the future this could link to /about-teams page