### PR TITLE
app API key crud, docs, fix route drift

### DIFF
--- a/src/assets/main.styl
+++ b/src/assets/main.styl
@@ -892,7 +892,7 @@ details
     margin-top 0 !important
     border-top-right-radius 0
     border-top-left-radius 0
-    img
+    img:not(.icon)
       border-radius var(--entity-radius)
 details[open]
   > summary

--- a/src/components/AppApiKeyListItem.vue
+++ b/src/components/AppApiKeyListItem.vue
@@ -17,7 +17,6 @@ const spaceStore = useSpaceStore()
 let unsubscribes
 
 onMounted(() => {
-  console.info('🐴 the component is now mounted.', spaceStore.getSpaceAllState)
   const globalActionUnsubscribe = globalStore.$onAction(
     ({ name, args }) => {
       if (name === 'clearDraggingItems') {

--- a/src/components/AppApiKeyListItem.vue
+++ b/src/components/AppApiKeyListItem.vue
@@ -89,15 +89,21 @@ const toggleConfirmRemoveKeyIsVisible = () => {
   clearConfirmations()
   state.confirmRemoveKeyIsVisible = value
 }
+const rotateApiKey = () => {
+  emit('rotateAppApiKey', props.appApiKey)
+}
+const removeApiKey = () => {
+  emit('removeAppApiKey', props.appApiKey)
+}
 </script>
 
 <template lang="pug">
-.app-api-key-list-item
+.app-api-key-list-item(@click="clearConfirmations")
   .row.title-row
     div
       .badge.circle-badge(:style="{ backgroundColor: appApiKey.color }")
       span(:title="appApiKey.name") {{ truncate(appApiKey.name) }}
-      button.small-button.scope-button(:title="scopeDescription(appApiKey)")
+      span.badge.secondary.scope-badge(:title="scopeDescription(appApiKey)")
         span {{ scope(appApiKey).friendlyName }}
   .row
     span.badge.secondary.api-key-string(:data-apikey="appApiKey.apiKey")
@@ -106,10 +112,27 @@ const toggleConfirmRemoveKeyIsVisible = () => {
     .button-wrap
       button.small-button(@click.left="copy($event, appApiKey.apiKey)" title="Copy App API Key")
         img.icon.copy(src="@/assets/copy.svg")
-      button.small-button.danger(title="Rotate Key" @click="toggleConfirmRotateKeyIsVisible")
+      button.small-button.danger(title="Rotate Key" @click.stop="toggleConfirmRotateKeyIsVisible" :class="{ active: state.confirmRotateKeyIsVisible }")
         img.refresh.icon(src="@/assets/refresh.svg")
-      button.small-button.danger(title="Remove Key" @click="toggleConfirmRemoveKeyIsVisible")
+      button.small-button.danger(title="Remove Key" @click.stop="toggleConfirmRemoveKeyIsVisible" :class="{ active: state.confirmRemoveKeyIsVisible }")
         img.icon.remove(src="@/assets/remove.svg")
+  //- rotate
+  section.subsection(v-if="state.confirmRotateKeyIsVisible" @click.stop)
+    .row
+      button.small-button(@click="clearConfirmations")
+        img.icon.cancel(src="@/assets/add.svg")
+      button.small-button.danger(@click="rotateApiKey")
+        img.refresh.icon(src="@/assets/refresh.svg")
+        span Rotate API Key
+  //- remove
+  section.subsection(v-if="state.confirmRemoveKeyIsVisible" @click.stop)
+    .row
+      button.small-button(@click="clearConfirmations")
+        img.icon.cancel(src="@/assets/add.svg")
+      button.small-button.danger(@click="removeApiKey" )
+        img.icon.remove(src="@/assets/remove.svg")
+        span Remove API Key
+
 </template>
 
 <style lang="stylus">
@@ -117,6 +140,16 @@ const toggleConfirmRemoveKeyIsVisible = () => {
   padding-bottom 10px
   margin-bottom 10px
   border-bottom 1px solid var(--primary-border)
-  .scope-button
+  .scope-badge
     margin-left 5px
+  .circle-badge
+    border-radius 100px
+    min-width initial
+    min-height initial
+    display inline-block
+    width 12px
+    height 12px
+  section.subsection
+    .row
+      justify-content flex-end
 </style>

--- a/src/components/AppApiKeyListItem.vue
+++ b/src/components/AppApiKeyListItem.vue
@@ -33,14 +33,14 @@ onBeforeUnmount(() => {
   unsubscribes()
 })
 
-const emit = defineEmits(['rotateAppApiKey', 'removeAppApiKey'])
+const emit = defineEmits(['rotateAppApiKey', 'deleteAppApiKey'])
 
 const props = defineProps({
   appApiKey: Object
 })
 const state = reactive({
   confirmRotateKeyIsVisible: false,
-  confirmRemoveKeyIsVisible: false,
+  confirmDeleteKeyIsVisible: false,
   isError: false,
   isLoading: false
 })
@@ -77,23 +77,23 @@ const truncate = (string) => {
 
 const clearConfirmations = () => {
   state.confirmRotateKeyIsVisible = false
-  state.confirmRemoveKeyIsVisible = false
+  state.confirmDeleteKeyIsVisible = false
 }
 const toggleConfirmRotateKeyIsVisible = () => {
   const value = !state.confirmRotateKeyIsVisible
   clearConfirmations()
   state.confirmRotateKeyIsVisible = value
 }
-const toggleConfirmRemoveKeyIsVisible = () => {
-  const value = !state.confirmRemoveKeyIsVisible
+const toggleConfirmDeleteKeyIsVisible = () => {
+  const value = !state.confirmDeleteKeyIsVisible
   clearConfirmations()
-  state.confirmRemoveKeyIsVisible = value
+  state.confirmDeleteKeyIsVisible = value
 }
 const rotateApiKey = () => {
   emit('rotateAppApiKey', props.appApiKey)
 }
-const removeApiKey = () => {
-  emit('removeAppApiKey', props.appApiKey)
+const deleteApiKey = () => {
+  emit('deleteAppApiKey', props.appApiKey)
 }
 </script>
 
@@ -114,7 +114,7 @@ const removeApiKey = () => {
         img.icon.copy(src="@/assets/copy.svg")
       button.small-button.danger(title="Rotate Key" @click.stop="toggleConfirmRotateKeyIsVisible" :class="{ active: state.confirmRotateKeyIsVisible }")
         img.refresh.icon(src="@/assets/refresh.svg")
-      button.small-button.danger(title="Remove Key" @click.stop="toggleConfirmRemoveKeyIsVisible" :class="{ active: state.confirmRemoveKeyIsVisible }")
+      button.small-button.danger(title="Delete Key" @click.stop="toggleConfirmDeleteKeyIsVisible" :class="{ active: state.confirmDeleteKeyIsVisible }")
         img.icon.remove(src="@/assets/remove.svg")
   //- rotate
   section.subsection(v-if="state.confirmRotateKeyIsVisible" @click.stop)
@@ -124,15 +124,14 @@ const removeApiKey = () => {
       button.small-button.danger(@click="rotateApiKey")
         img.refresh.icon(src="@/assets/refresh.svg")
         span Rotate API Key
-  //- remove
-  section.subsection(v-if="state.confirmRemoveKeyIsVisible" @click.stop)
+  //- delete
+  section.subsection(v-if="state.confirmDeleteKeyIsVisible" @click.stop)
     .row
       button.small-button(@click="clearConfirmations")
         img.icon.cancel(src="@/assets/add.svg")
-      button.small-button.danger(@click="removeApiKey" )
+      button.small-button.danger(@click="deleteApiKey" )
         img.icon.remove(src="@/assets/remove.svg")
-        span Remove API Key
-
+        span Delete API Key
 </template>
 
 <style lang="stylus">

--- a/src/components/AppApiKeyListItem.vue
+++ b/src/components/AppApiKeyListItem.vue
@@ -1,0 +1,122 @@
+<script setup>
+import { reactive, computed, onMounted, onBeforeUnmount, watch, ref, nextTick } from 'vue'
+
+import { useGlobalStore } from '@/stores/useGlobalStore'
+import { useCardStore } from '@/stores/useCardStore'
+import { useUserStore } from '@/stores/useUserStore'
+import { useSpaceStore } from '@/stores/useSpaceStore'
+
+import utils from '@/utils.js'
+import apiKeyScopes from '@/data/apiKeyScopes.js'
+
+const globalStore = useGlobalStore()
+const cardStore = useCardStore()
+const userStore = useUserStore()
+const spaceStore = useSpaceStore()
+
+let unsubscribes
+
+onMounted(() => {
+  console.info('🐴 the component is now mounted.', spaceStore.getSpaceAllState)
+  const globalActionUnsubscribe = globalStore.$onAction(
+    ({ name, args }) => {
+      if (name === 'clearDraggingItems') {
+        console.log('clearDraggingItems')
+      }
+    }
+  )
+  unsubscribes = () => {
+    globalActionUnsubscribe()
+  }
+})
+onBeforeUnmount(() => {
+  unsubscribes()
+})
+
+const emit = defineEmits(['rotateAppApiKey', 'removeAppApiKey'])
+
+const props = defineProps({
+  appApiKey: Object
+})
+const state = reactive({
+  confirmRotateKeyIsVisible: false,
+  confirmRemoveKeyIsVisible: false,
+  isError: false,
+  isLoading: false
+})
+
+const copy = async (event, text) => {
+  globalStore.clearNotificationsWithPosition()
+  const position = utils.cursorPositionInPage(event)
+  position.x += -40
+  try {
+    await navigator.clipboard.writeText(text)
+    globalStore.addNotificationWithPosition({ message: 'Copied', position, type: 'success', layer: 'app', icon: 'checkmark' })
+    console.info('🍇 copied', text)
+  } catch (error) {
+    console.warn('🚑 copyText', error)
+    globalStore.addNotificationWithPosition({ message: 'Copy Error', position, type: 'danger', layer: 'app', icon: 'cancel' })
+  }
+}
+const truncatedApiKey = (string, size) => {
+  size = size || 10
+  return `${string.substring(0, size)}…${string.substring(string.length - size, string.length)}`
+}
+const scope = (appApiKey) => {
+  return apiKeyScopes.find(scope => scope.name === appApiKey.scope)
+}
+const scopeDescription = (appApiKey) => {
+  const description = scope(appApiKey).description
+  return `Scope: ${description}`
+}
+const truncate = (string) => {
+  return utils.truncated(string, 18)
+}
+
+// confirmation
+
+const clearConfirmations = () => {
+  state.confirmRotateKeyIsVisible = false
+  state.confirmRemoveKeyIsVisible = false
+}
+const toggleConfirmRotateKeyIsVisible = () => {
+  const value = !state.confirmRotateKeyIsVisible
+  clearConfirmations()
+  state.confirmRotateKeyIsVisible = value
+}
+const toggleConfirmRemoveKeyIsVisible = () => {
+  const value = !state.confirmRemoveKeyIsVisible
+  clearConfirmations()
+  state.confirmRemoveKeyIsVisible = value
+}
+</script>
+
+<template lang="pug">
+.app-api-key-list-item
+  .row.title-row
+    div
+      .badge.circle-badge(:style="{ backgroundColor: appApiKey.color }")
+      span(:title="appApiKey.name") {{ truncate(appApiKey.name) }}
+      button.small-button.scope-button(:title="scopeDescription(appApiKey)")
+        span {{ scope(appApiKey).friendlyName }}
+  .row
+    span.badge.secondary.api-key-string(:data-apikey="appApiKey.apiKey")
+      img.icon.key(src="@/assets/key.svg")
+      code {{ truncatedApiKey(appApiKey.apiKey, 6) }}
+    .button-wrap
+      button.small-button(@click.left="copy($event, appApiKey.apiKey)" title="Copy App API Key")
+        img.icon.copy(src="@/assets/copy.svg")
+      button.small-button.danger(title="Rotate Key" @click="toggleConfirmRotateKeyIsVisible")
+        img.refresh.icon(src="@/assets/refresh.svg")
+      button.small-button.danger(title="Remove Key" @click="toggleConfirmRemoveKeyIsVisible")
+        img.icon.remove(src="@/assets/remove.svg")
+</template>
+
+<style lang="stylus">
+.app-api-key-list-item
+  padding-bottom 10px
+  margin-bottom 10px
+  border-bottom 1px solid var(--primary-border)
+  .scope-button
+    margin-left 5px
+</style>

--- a/src/components/AppApiKeyListItem.vue
+++ b/src/components/AppApiKeyListItem.vue
@@ -59,6 +59,7 @@ const copy = async (event, text) => {
   }
 }
 const truncatedApiKey = (string, size) => {
+  if (!string) { return }
   size = size || 10
   return `${string.substring(0, size)}…${string.substring(string.length - size, string.length)}`
 }

--- a/src/components/GroupDetailsInfo.vue
+++ b/src/components/GroupDetailsInfo.vue
@@ -67,7 +67,6 @@ const toggleColorPicker = () => {
 }
 const inputColorClasses = computed(() => {
   if (!props.isBackgroundColor) { return }
-  console.log(utils.colorClasses({ backgroundColor: props.group.color }), props.group.color)
   return utils.colorClasses({ backgroundColor: props.group.color })
 })
 
@@ -129,7 +128,6 @@ const groupName = computed({
     name="groupName"
     maxlength=100
     ref="nameInputElement"
-    @keydown.enter.exact.prevent="createGroup"
     @keyup.stop.backspace
     @keyup.stop.enter
     @mouseup.stop

--- a/src/components/dialogs/AddAppApiKey.vue
+++ b/src/components/dialogs/AddAppApiKey.vue
@@ -147,13 +147,15 @@ dialog.narrow.add-app-api-key(
   ref="dialogElement"
   :style="{'max-height': state.dialogHeight + 'px'}"
 )
+  section.title-section
+    p New App API Key
   section
     .row
       .button-wrap
         .segmented-buttons
           button.change-color(@click.left.stop="toggleColorPicker" :class="{active: state.colorPickerIsVisible}" title="Change Color")
             .current-color(:style="{ background: color }")
-        ColorPicker(:currentColor="color" :visible="state.colorPickerIsVisible" @selectedColor="updateColor")
+        ColorPicker(:currentColor="color" :visible="state.colorPickerIsVisible" @selectedColor="updateColor" :luminosityIsDark="true")
       //- name
       input.name(
         placeholder="App API Key Name"

--- a/src/components/dialogs/AddAppApiKey.vue
+++ b/src/components/dialogs/AddAppApiKey.vue
@@ -9,6 +9,8 @@ import ColorPicker from '@/components/dialogs/ColorPicker.vue'
 import ApiKeyScopePicker from '@/components/dialogs/ApiKeyScopePicker.vue'
 import apiKeyScopes from '@/data/apiKeyScopes.js'
 
+import { nanoid } from 'nanoid'
+
 const globalStore = useGlobalStore()
 
 let unsubscribes
@@ -129,7 +131,7 @@ const updateCurrentScope = (scope) => {
 
 const createAppApiKey = () => {
   const appApiKey = {
-    id: self.crypto.randomUUID(),
+    id: nanoid(),
     name: state.name,
     color: state.color,
     apiKey: self.crypto.randomUUID(),

--- a/src/components/dialogs/AddAppApiKey.vue
+++ b/src/components/dialogs/AddAppApiKey.vue
@@ -121,8 +121,8 @@ const toggleApiKeyScopePickerIsVisible = () => {
   state.apiKeyScopePickerIsVisible = value
 }
 const updateCurrentScope = (scope) => {
-  console.log('❤️❤️❤️', scope)
-  // state.scope = scope.name
+  state.scope = scope
+  closeDialogs()
 }
 
 // submit
@@ -175,7 +175,7 @@ dialog.narrow.add-app-api-key(
         button(@click.stop="toggleApiKeyScopePickerIsVisible" :class="{active: state.apiKeyScopePickerIsVisible}")
           span Scope
           span.badge.secondary.scope-badge {{currentScope.friendlyName}}
-        ApiKeyScopePicker(:visible="state.apiKeyScopePickerIsVisible" :currentScope="state.scope" @updateCurrentScope="updateCurrentScope")
+        ApiKeyScopePicker(:visible="state.apiKeyScopePickerIsVisible" :currentScopeName="state.scope" @updateCurrentScope="updateCurrentScope")
     //- create
     .row
       button(@click.stop="createAppApiKey")
@@ -201,5 +201,6 @@ dialog.add-app-api-key
     margin-right 5px
   .scope-badge
     margin-left 5px
+    margin-right 0
 
 </style>

--- a/src/components/dialogs/AddAppApiKey.vue
+++ b/src/components/dialogs/AddAppApiKey.vue
@@ -6,6 +6,7 @@ import { useGlobalStore } from '@/stores/useGlobalStore'
 import utils from '@/utils.js'
 import randomColor from 'randomcolor'
 import ColorPicker from '@/components/dialogs/ColorPicker.vue'
+import ApiKeyScopePicker from '@/components/dialogs/ApiKeyScopePicker.vue'
 import apiKeyScopes from '@/data/apiKeyScopes.js'
 
 const globalStore = useGlobalStore()
@@ -41,6 +42,7 @@ const props = defineProps({
 const state = reactive({
   dialogHeight: null,
   colorPickerIsVisible: false,
+  apiKeyScopePickerIsVisible: false,
   name: 'App Name',
   color: 'red',
   scope: 'read'
@@ -51,6 +53,7 @@ watch(() => props.visible, (value, prevValue) => {
     state.color = randomColor({ luminosity: 'dark' })
     updateDialogHeight()
     focusNameInput()
+    closeDialogs()
   }
 })
 
@@ -62,6 +65,7 @@ const updateDialogHeight = async () => {
 }
 const closeDialogs = (shouldEmit) => {
   state.colorPickerIsVisible = false
+  state.apiKeyScopePickerIsVisible = false
   if (shouldEmit) {
     emit('childDialogIsVisible', false)
   }
@@ -106,6 +110,21 @@ const name = computed({
   }
 })
 
+// scope
+
+const currentScope = computed(() => {
+  return apiKeyScopes.find(scope => scope.name === state.scope)
+})
+const toggleApiKeyScopePickerIsVisible = () => {
+  const value = !state.apiKeyScopePickerIsVisible
+  closeDialogs()
+  state.apiKeyScopePickerIsVisible = value
+}
+const updateCurrentScope = (scope) => {
+  console.log('❤️❤️❤️', scope)
+  // state.scope = scope.name
+}
+
 // submit
 
 const createAppApiKey = () => {
@@ -148,9 +167,14 @@ dialog.narrow.add-app-api-key(
         @touchend.stop
         :class="inputColorClasses"
       )
+    //- scope picker
     .row
-      button
-        span User Scope
+      .button-wrap
+        button(@click.stop="toggleApiKeyScopePickerIsVisible" :class="{active: state.apiKeyScopePickerIsVisible}")
+          span Scope
+          span.badge.secondary.scope-badge {{currentScope.friendlyName}}
+        ApiKeyScopePicker(:visible="state.apiKeyScopePickerIsVisible" :currentScope="state.scope" @updateCurrentScope="updateCurrentScope")
+    //- create
     .row
       button(@click.stop="createAppApiKey")
         img.icon.add-icon(src="@/assets/add.svg")
@@ -173,4 +197,7 @@ dialog.add-app-api-key
     margin-bottom 0
   .button-label
     margin-right 5px
+  .scope-badge
+    margin-left 5px
+
 </style>

--- a/src/components/dialogs/AddAppApiKey.vue
+++ b/src/components/dialogs/AddAppApiKey.vue
@@ -129,6 +129,7 @@ const updateCurrentScope = (scope) => {
 
 const createAppApiKey = () => {
   const appApiKey = {
+    id: self.crypto.randomUUID(),
     name: state.name,
     color: state.color,
     apiKey: self.crypto.randomUUID(),

--- a/src/components/dialogs/AddAppApiKey.vue
+++ b/src/components/dialogs/AddAppApiKey.vue
@@ -47,7 +47,8 @@ const state = reactive({
   apiKeyScopePickerIsVisible: false,
   name: 'App Name',
   color: 'red',
-  scope: 'read'
+  scope: 'read',
+  errorNameIsRequired: false
 })
 
 watch(() => props.visible, (value, prevValue) => {
@@ -130,6 +131,11 @@ const updateCurrentScope = (scope) => {
 // submit
 
 const createAppApiKey = () => {
+  state.errorNameIsRequired = false
+  if (!state.name) {
+    state.errorNameIsRequired = true
+    return
+  }
   const appApiKey = {
     id: nanoid(),
     name: state.name,
@@ -161,7 +167,7 @@ dialog.narrow.add-app-api-key(
         ColorPicker(:currentColor="color" :visible="state.colorPickerIsVisible" @selectedColor="updateColor" :luminosityIsDark="true")
       //- name
       input.name(
-        placeholder="App API Key Name"
+        placeholder="App Name"
         v-model="name"
         name="apiKeyName"
         maxlength=100
@@ -184,6 +190,9 @@ dialog.narrow.add-app-api-key(
       button(@click.stop="createAppApiKey")
         img.icon.add-icon(src="@/assets/add.svg")
         span Create API Key
+    //- error
+    .row(v-if="state.errorNameIsRequired")
+      .badge.danger App Name is required
 </template>
 
 <style lang="stylus">

--- a/src/components/dialogs/AddAppApiKey.vue
+++ b/src/components/dialogs/AddAppApiKey.vue
@@ -2,28 +2,25 @@
 import { reactive, computed, onMounted, onBeforeUnmount, watch, ref, nextTick } from 'vue'
 
 import { useGlobalStore } from '@/stores/useGlobalStore'
-import { useCardStore } from '@/stores/useCardStore'
-import { useUserStore } from '@/stores/useUserStore'
-import { useSpaceStore } from '@/stores/useSpaceStore'
 
 import utils from '@/utils.js'
+import randomColor from 'randomcolor'
+import ColorPicker from '@/components/dialogs/ColorPicker.vue'
+import apiKeyScopes from '@/data/apiKeyScopes.js'
 
 const globalStore = useGlobalStore()
-const cardStore = useCardStore()
-const userStore = useUserStore()
-const spaceStore = useSpaceStore()
 
 let unsubscribes
 
 const dialogElement = ref(null)
+const nameInputElement = ref(null)
 
 onMounted(() => {
   window.addEventListener('resize', updateDialogHeight)
-
   const globalActionUnsubscribe = globalStore.$onAction(
     ({ name, args }) => {
-      if (name === 'clearDraggingItems') {
-        console.log('clearDraggingItems')
+      if (name === 'triggerCloseChildDialogs') {
+        closeDialogs()
       }
     }
   )
@@ -32,26 +29,30 @@ onMounted(() => {
   }
 })
 onBeforeUnmount(() => {
-  unsubscribes()
   window.removeEventListener('resize', updateDialogHeight)
+  unsubscribes()
 })
 
-const emit = defineEmits(['updateCount'])
+const emit = defineEmits(['childDialogIsVisible', 'createAppApiKey'])
 
 const props = defineProps({
   visible: Boolean
 })
 const state = reactive({
-  count: 0,
-  dialogHeight: null
+  dialogHeight: null,
+  colorPickerIsVisible: false,
+  name: 'App Name',
+  color: 'red',
+  scope: 'read'
 })
 
 watch(() => props.visible, (value, prevValue) => {
   if (value) {
+    state.color = randomColor({ luminosity: 'dark' })
     updateDialogHeight()
+    focusNameInput()
   }
 })
-// watch(() => globalStore.spaceZoomPercent, (value, prevValue) => {
 
 const updateDialogHeight = async () => {
   if (!props.visible) { return }
@@ -59,25 +60,117 @@ const updateDialogHeight = async () => {
   const element = dialogElement.value
   state.dialogHeight = utils.elementHeight(element)
 }
+const closeDialogs = (shouldEmit) => {
+  state.colorPickerIsVisible = false
+  if (shouldEmit) {
+    emit('childDialogIsVisible', false)
+  }
+}
+const clearState = () => {
+  state.name = 'App Name'
+  state.scope = 'read'
+}
 
-const themeName = computed(() => userStore.theme)
-const incrementBy = () => {
-  state.count = state.count + 1
-  emit('updateCount', state.count)
-  // themeStore.updateThemeIsSystem(false)
+// color
+
+const color = computed(() => state.color)
+const updateColor = (newValue) => {
+  state.color = newValue
+}
+const toggleColorPicker = () => {
+  const isVisible = state.colorPickerIsVisible
+  closeDialogs(true)
+  state.colorPickerIsVisible = !isVisible
+  emit('childDialogIsVisible', !isVisible)
+}
+const inputColorClasses = computed(() => {
+  if (!props.isBackgroundColor) { return }
+  return utils.colorClasses({ backgroundColor: state.color })
+})
+
+// name
+
+const focusNameInput = async () => {
+  await nextTick()
+  const element = nameInputElement.value
+  if (!element) { return }
+  element.focus()
+  element.select()
+}
+const name = computed({
+  get () {
+    return state.name
+  },
+  set (newValue) {
+    state.name = newValue
+  }
+})
+
+// submit
+
+const createAppApiKey = () => {
+  const appApiKey = {
+    name: state.name,
+    color: state.color,
+    apiKey: self.crypto.randomUUID(),
+    scope: state.scope
+  }
+  emit('createAppApiKey', appApiKey)
+  clearState()
 }
 </script>
 
 <template lang="pug">
-dialog.narrow.add-app-api-key(v-if="props.visible" :open="props.visible" @click.left.stop ref="dialogElement" :style="{'max-height': state.dialogHeight + 'px'}")
+dialog.narrow.add-app-api-key(
+  v-if="props.visible"
+  :open="props.visible"
+  @click.left.stop="closeDialogs"
+  ref="dialogElement"
+  :style="{'max-height': state.dialogHeight + 'px'}"
+)
   section
-    button(@click="incrementBy")
-      span Count is: {{ state.count }}
-    p Current theme is: {{ themeName }}
+    .row
+      .button-wrap
+        .segmented-buttons
+          button.change-color(@click.left.stop="toggleColorPicker" :class="{active: state.colorPickerIsVisible}" title="Change Color")
+            .current-color(:style="{ background: color }")
+        ColorPicker(:currentColor="color" :visible="state.colorPickerIsVisible" @selectedColor="updateColor")
+      //- name
+      input.name(
+        placeholder="App API Key Name"
+        v-model="name"
+        name="apiKeyName"
+        maxlength=100
+        ref="nameInputElement"
+        @keyup.stop.backspace
+        @keyup.stop.enter
+        @mouseup.stop
+        @touchend.stop
+        :class="inputColorClasses"
+      )
+    .row
+      button
+        span User Scope
+    .row
+      button(@click.stop="createAppApiKey")
+        img.icon.add-icon(src="@/assets/add.svg")
+        span Create API Key
 </template>
 
 <style lang="stylus">
 dialog.add-app-api-key
   left initial
   right 8px
+  top 22px
+  .segmented-buttons
+    display flex
+    align-items flex-start
+  button.change-color
+    .current-color
+      border-radius 10px
+  input.name
+    margin-left 6px
+    margin-bottom 0
+  .button-label
+    margin-right 5px
 </style>

--- a/src/components/dialogs/AddAppApiKey.vue
+++ b/src/components/dialogs/AddAppApiKey.vue
@@ -1,0 +1,83 @@
+<script setup>
+import { reactive, computed, onMounted, onBeforeUnmount, watch, ref, nextTick } from 'vue'
+
+import { useGlobalStore } from '@/stores/useGlobalStore'
+import { useCardStore } from '@/stores/useCardStore'
+import { useUserStore } from '@/stores/useUserStore'
+import { useSpaceStore } from '@/stores/useSpaceStore'
+
+import utils from '@/utils.js'
+
+const globalStore = useGlobalStore()
+const cardStore = useCardStore()
+const userStore = useUserStore()
+const spaceStore = useSpaceStore()
+
+let unsubscribes
+
+const dialogElement = ref(null)
+
+onMounted(() => {
+  window.addEventListener('resize', updateDialogHeight)
+
+  const globalActionUnsubscribe = globalStore.$onAction(
+    ({ name, args }) => {
+      if (name === 'clearDraggingItems') {
+        console.log('clearDraggingItems')
+      }
+    }
+  )
+  unsubscribes = () => {
+    globalActionUnsubscribe()
+  }
+})
+onBeforeUnmount(() => {
+  unsubscribes()
+  window.removeEventListener('resize', updateDialogHeight)
+})
+
+const emit = defineEmits(['updateCount'])
+
+const props = defineProps({
+  visible: Boolean
+})
+const state = reactive({
+  count: 0,
+  dialogHeight: null
+})
+
+watch(() => props.visible, (value, prevValue) => {
+  if (value) {
+    updateDialogHeight()
+  }
+})
+// watch(() => globalStore.spaceZoomPercent, (value, prevValue) => {
+
+const updateDialogHeight = async () => {
+  if (!props.visible) { return }
+  await nextTick()
+  const element = dialogElement.value
+  state.dialogHeight = utils.elementHeight(element)
+}
+
+const themeName = computed(() => userStore.theme)
+const incrementBy = () => {
+  state.count = state.count + 1
+  emit('updateCount', state.count)
+  // themeStore.updateThemeIsSystem(false)
+}
+</script>
+
+<template lang="pug">
+dialog.narrow.add-app-api-key(v-if="props.visible" :open="props.visible" @click.left.stop ref="dialogElement" :style="{'max-height': state.dialogHeight + 'px'}")
+  section
+    button(@click="incrementBy")
+      span Count is: {{ state.count }}
+    p Current theme is: {{ themeName }}
+</template>
+
+<style lang="stylus">
+dialog.add-app-api-key
+  left initial
+  right 8px
+</style>

--- a/src/components/dialogs/AddGroup.vue
+++ b/src/components/dialogs/AddGroup.vue
@@ -100,6 +100,8 @@ const createGroup = async () => {
 
 <template lang="pug">
 dialog.narrow.add-group(v-if="visible" :open="visible" @click.left.stop="closeDialogs" ref="dialogElement" :style="{'max-height': state.dialogHeight + 'px'}")
+  section.title-section
+    p New Group
   UpgradedUserRequired(:message="upgradeMessage")
   section(v-if="currentUserIsUpgraded")
     GroupDetailsInfo(:group="state.group" @updateGroup="updateGroup")

--- a/src/components/dialogs/ApiKeyScopePicker.vue
+++ b/src/components/dialogs/ApiKeyScopePicker.vue
@@ -1,0 +1,83 @@
+<script setup>
+import { reactive, computed, onMounted, onBeforeUnmount, watch, ref, nextTick } from 'vue'
+
+import { useGlobalStore } from '@/stores/useGlobalStore'
+import { useCardStore } from '@/stores/useCardStore'
+import { useUserStore } from '@/stores/useUserStore'
+import { useSpaceStore } from '@/stores/useSpaceStore'
+
+import utils from '@/utils.js'
+
+const globalStore = useGlobalStore()
+const cardStore = useCardStore()
+const userStore = useUserStore()
+const spaceStore = useSpaceStore()
+
+let unsubscribes
+
+const dialogElement = ref(null)
+
+onMounted(() => {
+  window.addEventListener('resize', updateDialogHeight)
+
+  const globalActionUnsubscribe = globalStore.$onAction(
+    ({ name, args }) => {
+      if (name === 'clearDraggingItems') {
+        console.log('clearDraggingItems')
+      }
+    }
+  )
+  unsubscribes = () => {
+    globalActionUnsubscribe()
+  }
+})
+onBeforeUnmount(() => {
+  unsubscribes()
+  window.removeEventListener('resize', updateDialogHeight)
+})
+
+const emit = defineEmits(['updateCount'])
+
+const props = defineProps({
+  visible: Boolean
+})
+const state = reactive({
+  count: 0,
+  dialogHeight: null
+})
+
+watch(() => props.visible, (value, prevValue) => {
+  if (value) {
+    updateDialogHeight()
+  }
+})
+// watch(() => globalStore.spaceZoomPercent, (value, prevValue) => {
+
+const updateDialogHeight = async () => {
+  if (!props.visible) { return }
+  await nextTick()
+  const element = dialogElement.value
+  state.dialogHeight = utils.elementHeight(element)
+}
+
+const themeName = computed(() => userStore.theme)
+const incrementBy = () => {
+  state.count = state.count + 1
+  emit('updateCount', state.count)
+  // themeStore.updateThemeIsSystem(false)
+}
+</script>
+
+<template lang="pug">
+dialog.narrow.dialog-name(v-if="props.visible" :open="props.visible" @click.left.stop ref="dialogElement" :style="{'max-height': state.dialogHeight + 'px'}")
+  section.title-section
+    p blank dialog, please duplicate
+  section
+    button(@click="incrementBy")
+      span Count is: {{ state.count }}
+    p Current theme is: {{ themeName }}
+</template>
+
+<style lang="stylus">
+// dialog.dialog-name
+</style>

--- a/src/components/dialogs/ApiKeyScopePicker.vue
+++ b/src/components/dialogs/ApiKeyScopePicker.vue
@@ -2,6 +2,7 @@
 import { reactive, computed, onMounted, onBeforeUnmount, watch, ref, nextTick } from 'vue'
 
 import utils from '@/utils.js'
+import apiKeyScopes from '@/data/apiKeyScopes.js'
 
 const dialogElement = ref(null)
 
@@ -16,7 +17,7 @@ const emit = defineEmits(['updateCurrentScope'])
 
 const props = defineProps({
   visible: Boolean,
-  currentScope: Object
+  currentScopeName: String
 })
 const state = reactive({
   dialogHeight: null
@@ -35,14 +36,34 @@ const updateDialogHeight = async () => {
   state.dialogHeight = utils.elementHeight(element)
 }
 
+const scopeIsActive = (scope) => {
+  return scope.name === props.currentScopeName
+}
+
+const select = (scope) => {
+  emit('updateCurrentScope', scope.name)
+}
 </script>
 
 <template lang="pug">
 dialog.narrow.api-key-scope-picker(v-if="props.visible" :open="props.visible" @click.left.stop ref="dialogElement" :style="{'max-height': state.dialogHeight + 'px'}")
-  section.title-section
-    p blank dialog, please duplicate
+  section.results-section
+    ul.results-list
+      template(v-for="(scope in apiKeyScopes")
+        li(:class="{ active: scopeIsActive(scope) }" @click.left="select(scope)")
+          span.badge.secondary {{ scope.friendlyName }}
+          p.description {{ scope.description }}
 </template>
 
 <style lang="stylus">
-// dialog.api-key-scope-picker
+dialog.api-key-scope-picker
+  overflow auto
+  .results-section
+    padding-top 4px
+  .badge
+    display inline-block
+  li
+    display block
+  .description
+    margin-top 3px
 </style>

--- a/src/components/dialogs/ApiKeyScopePicker.vue
+++ b/src/components/dialogs/ApiKeyScopePicker.vue
@@ -1,48 +1,24 @@
 <script setup>
 import { reactive, computed, onMounted, onBeforeUnmount, watch, ref, nextTick } from 'vue'
 
-import { useGlobalStore } from '@/stores/useGlobalStore'
-import { useCardStore } from '@/stores/useCardStore'
-import { useUserStore } from '@/stores/useUserStore'
-import { useSpaceStore } from '@/stores/useSpaceStore'
-
 import utils from '@/utils.js'
-
-const globalStore = useGlobalStore()
-const cardStore = useCardStore()
-const userStore = useUserStore()
-const spaceStore = useSpaceStore()
-
-let unsubscribes
 
 const dialogElement = ref(null)
 
 onMounted(() => {
   window.addEventListener('resize', updateDialogHeight)
-
-  const globalActionUnsubscribe = globalStore.$onAction(
-    ({ name, args }) => {
-      if (name === 'clearDraggingItems') {
-        console.log('clearDraggingItems')
-      }
-    }
-  )
-  unsubscribes = () => {
-    globalActionUnsubscribe()
-  }
 })
 onBeforeUnmount(() => {
-  unsubscribes()
   window.removeEventListener('resize', updateDialogHeight)
 })
 
-const emit = defineEmits(['updateCount'])
+const emit = defineEmits(['updateCurrentScope'])
 
 const props = defineProps({
-  visible: Boolean
+  visible: Boolean,
+  currentScope: Object
 })
 const state = reactive({
-  count: 0,
   dialogHeight: null
 })
 
@@ -51,7 +27,6 @@ watch(() => props.visible, (value, prevValue) => {
     updateDialogHeight()
   }
 })
-// watch(() => globalStore.spaceZoomPercent, (value, prevValue) => {
 
 const updateDialogHeight = async () => {
   if (!props.visible) { return }
@@ -60,24 +35,14 @@ const updateDialogHeight = async () => {
   state.dialogHeight = utils.elementHeight(element)
 }
 
-const themeName = computed(() => userStore.theme)
-const incrementBy = () => {
-  state.count = state.count + 1
-  emit('updateCount', state.count)
-  // themeStore.updateThemeIsSystem(false)
-}
 </script>
 
 <template lang="pug">
-dialog.narrow.dialog-name(v-if="props.visible" :open="props.visible" @click.left.stop ref="dialogElement" :style="{'max-height': state.dialogHeight + 'px'}")
+dialog.narrow.api-key-scope-picker(v-if="props.visible" :open="props.visible" @click.left.stop ref="dialogElement" :style="{'max-height': state.dialogHeight + 'px'}")
   section.title-section
     p blank dialog, please duplicate
-  section
-    button(@click="incrementBy")
-      span Count is: {{ state.count }}
-    p Current theme is: {{ themeName }}
 </template>
 
 <style lang="stylus">
-// dialog.dialog-name
+// dialog.api-key-scope-picker
 </style>

--- a/src/components/dialogs/DeleteAccountConfirmation.vue
+++ b/src/components/dialogs/DeleteAccountConfirmation.vue
@@ -3,10 +3,12 @@ import { reactive, computed, onMounted, onBeforeUnmount, watch, ref, nextTick } 
 
 import { useApiStore } from '@/stores/useApiStore'
 import { useUserStore } from '@/stores/useUserStore'
+import { useGlobalStore } from '@/stores/useGlobalStore'
 import Loader from '@/components/Loader.vue'
 import cache from '@/cache.js'
 import utils from '@/utils.js'
 
+const globalStore = useGlobalStore()
 const apiStore = useApiStore()
 const userStore = useUserStore()
 
@@ -70,6 +72,9 @@ const deleteUserPermanent = async () => {
     state.loading.deleteUserPermanent = false
   }
 }
+const cancel = () => {
+  globalStore.triggerCloseChildDialogs()
+}
 </script>
 
 <template lang="pug">
@@ -91,7 +96,7 @@ dialog.delete-all-confirmation.narrow(v-if="props.visible" :open="props.visible"
         input(type="text" v-model="state.deleteUserConfirmation" placeholder="Confirmation Input")
     .row
       .segmented-buttons
-        button(@click.left="toggleDeleteAllConfirmationVisible")
+        button(@click.left="cancel")
           img.icon.cancel(src="@/assets/add.svg")
           span Cancel
         button.danger(@click.left="deleteUserPermanent" :disabled="!deleteUserPermanentIsConfirmed" class="{disabled: !deleteUserPermanentIsConfirmed}")
@@ -108,9 +113,4 @@ dialog.delete-all-confirmation
     padding-bottom 2px
   .subsection.danger
     background-color var(--danger-background)
-  @media(max-height 700px)
-    top -100px
-  @media(max-height 500px)
-    top -200px
-
 </style>

--- a/src/components/dialogs/ModeratorActions.vue
+++ b/src/components/dialogs/ModeratorActions.vue
@@ -166,8 +166,6 @@ dialog.narrow.moderator-actions(v-if="props.visible" :open="props.visible" @clic
 <style lang="stylus">
 dialog.moderator-actions
   overflow auto
-  @media(max-height 600px)
-    top -200px
   form,
   section.subsection
     margin-top 10px

--- a/src/components/dialogs/NotificationSettings.vue
+++ b/src/components/dialogs/NotificationSettings.vue
@@ -106,7 +106,7 @@ dialog.narrow.notification-settings(v-if="props.visible" :open="props.visible" @
       button(@click.left="triggerSignUpOrInIsVisible") Sign Up or In
   template(v-else)
     section
-      .row A quarterly-ish newsletter about new features and product strategy
+      .row A quarterly-ish newsletter about new features and growing Kinopio
       .row
         label(:class="{active: shouldEmailBulletin}" @click.left.prevent="toggleShouldEmailBulletin" @keydown.stop.enter="toggleShouldEmailBulletin")
           input(type="checkbox" v-model="shouldEmailBulletin")

--- a/src/components/dialogs/NotificationSettings.vue
+++ b/src/components/dialogs/NotificationSettings.vue
@@ -106,7 +106,7 @@ dialog.narrow.notification-settings(v-if="props.visible" :open="props.visible" @
       button(@click.left="triggerSignUpOrInIsVisible") Sign Up or In
   template(v-else)
     section
-      .row A biweekly newsletter about upcoming features and cool spaces
+      .row A quarterly-ish newsletter about new features and product strategy
       .row
         label(:class="{active: shouldEmailBulletin}" @click.left.prevent="toggleShouldEmailBulletin" @keydown.stop.enter="toggleShouldEmailBulletin")
           input(type="checkbox" v-model="shouldEmailBulletin")

--- a/src/components/dialogs/UserAccountSettings.vue
+++ b/src/components/dialogs/UserAccountSettings.vue
@@ -126,6 +126,4 @@ dialog.narrow.update-email(v-if="props.visible" :open="props.visible" @click.lef
 <style lang="stylus">
 .update-email
   overflow auto
-  @media(max-height 650px)
-    top -100px !important
 </style>

--- a/src/components/dialogs/UserApiInfo.vue
+++ b/src/components/dialogs/UserApiInfo.vue
@@ -107,10 +107,18 @@ const updateAppApiKeys = async () => {
 }
 const updateAppApiKey = async (update) => {
   try {
-    // TODO update state by id
     state.isLoading = true
     state.isError = false
-    // TODO await apiStore.
+    state.appApiKeys = state.appApiKeys.map(appApiKey => {
+      if (appApiKey.id === update.id) {
+        const keys = Object.keys(update)
+        keys.forEach(key => {
+          appApiKey[key] = update[key]
+        })
+      }
+      return appApiKey
+    })
+    await apiStore.updateAppApiKey(update)
   } catch (error) {
     console.error('🚒 updateAppApiKey', error)
     state.isError = true
@@ -125,13 +133,12 @@ const rotateAppApiKey = (appApiKey) => {
   }
   updateAppApiKey(update)
 }
-const removeAppApiKey = async (appApiKey) => {
-  console.log('🍒')
+const deleteAppApiKey = async (update) => {
   try {
     state.isLoading = true
     state.isError = false
-    // TODO remove from state
-    // TODO await apiStore.removeAppApiKey
+    state.appApiKeys = state.appApiKeys.filter(appApiKey => appApiKey.id !== update.id)
+    await apiStore.deleteAppApiKey(update)
   } catch (error) {
     console.error('🚒 updateAppApiKey', error)
     state.isError = true
@@ -176,7 +183,7 @@ dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop
     .badge.danger(v-if="state.error")
       span (シ_ _)シ Something went wrong, Please try again or contact support
     template(v-for="appApiKey in state.appApiKeys" :key="appApiKey.apiKey")
-      AppApiKeyListItem(:appApiKey="appApiKey" @removeAppApiKey="removeAppApiKey" @rotateAppApiKey="rotateAppApiKey")
+      AppApiKeyListItem(:appApiKey="appApiKey" @deleteAppApiKey="deleteAppApiKey" @rotateAppApiKey="rotateAppApiKey")
     //- user api key
     details
       summary User API Key

--- a/src/components/dialogs/UserApiInfo.vue
+++ b/src/components/dialogs/UserApiInfo.vue
@@ -6,6 +6,9 @@ import { useUserStore } from '@/stores/useUserStore'
 import { useSpaceStore } from '@/stores/useSpaceStore'
 
 import utils from '@/utils.js'
+import apiKeyScopes from '@/data/apiKeyScopes.js'
+import OfflineBadge from '@/components/OfflineBadge.vue'
+import Loader from '@/components/Loader.vue'
 
 const globalStore = useGlobalStore()
 const userStore = useUserStore()
@@ -25,7 +28,10 @@ const props = defineProps({
   visible: Boolean
 })
 const state = reactive({
-  dialogHeight: null
+  dialogHeight: null,
+  isLoading: false,
+  isError: false,
+  appApiKeys: []
 })
 
 watch(() => props.visible, (value, prevValue) => {
@@ -70,6 +76,21 @@ const truncatedCensoredApiKey = (string, size) => {
 
 // app api keys
 
+const updateAppApiKeys = async () => {
+  if (!globalStore.isOnline) { return }
+  try {
+    state.isLoading = true
+    state.isError = false
+    // TODO should load from api onmount, state.error
+
+    // state.appApiKeys =
+  } catch (error) {
+    state.isError = true
+  }
+  state.isLoading = false
+}
+
+// STUB : replace w state.appApiKeys
 const appApiKeys = computed(() => {
   return [
     {
@@ -84,11 +105,9 @@ const appApiKeys = computed(() => {
     }
   ]
 })
-
-// delete = can edit and delete
-// edit
-// read
-// user
+const scope = (appApiKey) => {
+  return apiKeyScopes.find(scope => scope.name === appApiKey.name)
+}
 
 </script>
 
@@ -116,6 +135,7 @@ dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop
   section.title-section
     .row.title-row
       span
+        Loader(:visible="state.isLoading" :isSmall="true")
         span API Keys
       .button-wrap
         button.small-button
@@ -123,16 +143,23 @@ dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop
           span App Key
         //- AddAppApiKey
           //- name scope-picker
+    OfflineBadge
 
-  //- results list ???
-  //- list app api keys
-  //- name, scope
-  //- key [copy]
-    [rotate] [remove] in AppApiKeyDetails
-    //- ^ confirm for both
-
-  //- show user api key
+  //- app api keys
   section
+    //- (v-if="!state.loading && state.appApiKeys.length")
+
+    //- results list ???
+    //- list app api keys
+    //- name, scope
+    //- key [copy]
+      [rotate] [remove] in AppApiKeyDetails
+      //- ^ confirm for both
+
+    .badge.danger(v-if="state.error")
+      span (シ_ _)シ Something went wrong, Please try again or contact support
+
+    //- user api key
     details
       summary User API Key
       section.subsection
@@ -143,7 +170,7 @@ dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop
             button.small-button(@click.left="copy($event, userApiKey)" title="Copy User API Key")
               img.icon.copy(src="@/assets/copy.svg")
         .row
-          .badge.danger.copy-api-keys
+          .badge.danger
             p
               span Your user API key has full root permissions to your account, so keep it private.
 </template>
@@ -152,7 +179,7 @@ dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop
 dialog.user-api-info
   left -18px
   overflow auto
-  .copy-api-keys
-    padding-top 4px
-    padding-bottom 4px
+  .loader
+    vertical-align -1px
+    margin-right 5px
 </style>

--- a/src/components/dialogs/UserApiInfo.vue
+++ b/src/components/dialogs/UserApiInfo.vue
@@ -59,6 +59,9 @@ const toggleAddAppApiKeyIsVisible = () => {
   closeDialogs()
   state.addAppApiKeyIsVisible = value
 }
+const childDialogIsVisible = computed(() => {
+  return state.addAppApiKeyIsVisible
+})
 
 // data
 
@@ -157,12 +160,31 @@ const deleteAppApiKey = async (update) => {
   state.isLoading = false
 }
 const createAppApiKey = (apiKey) => {
+  closeDialogs()
+  console.log('🍒🍒', apiKey)
   // - color, name, scope-picker/list, id
+  try {
+    state.isLoading = true
+    state.isError = false
+    state.appApiKeys.push(apiKey)
+    // await apiStore.deleteAppApiKey(update)
+  } catch (error) {
+    console.error('🚒 updateAppApiKey', error)
+    state.isError = true
+  }
+  state.isLoading = false
 }
 </script>
 
 <template lang="pug">
-dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop="closeDialogs" ref="dialogElement" :style="{'max-height': state.dialogHeight + 'px'}")
+dialog.user-api-info(
+  v-if="props.visible"
+  :open="props.visible"
+  @click.left.stop="closeDialogs"
+  ref="dialogElement"
+  :style="{'max-height': state.dialogHeight + 'px'}"
+  :class="{ overflow: !childDialogIsVisible }"
+)
   section.title-section
     .row.title-row
       span API
@@ -171,6 +193,8 @@ dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop
           button.small-button
             span API Docs{{' '}}
             img.icon.visit(src="@/assets/visit.svg")
+      AddAppApiKey(:visible="state.addAppApiKeyIsVisible" @createAppApiKey="createAppApiKey")
+
   //- user id
   section
     p User Id
@@ -189,7 +213,6 @@ dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop
         button.small-button(@click.stop="toggleAddAppApiKeyIsVisible" :class="{active: state.addAppApiKeyIsVisible}")
           img.icon.add-icon(src="@/assets/add.svg")
           span New
-        AddAppApiKey(:visible="state.addAppApiKeyIsVisible" @createAppApiKey="createAppApiKey")
     OfflineBadge
   //- app api keys
   section.app-api-keys(v-if="!state.loading && state.appApiKeys.length")
@@ -216,7 +239,8 @@ dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop
 <style lang="stylus">
 dialog.user-api-info
   left -18px
-  overflow auto
+  &.overflow
+    overflow auto
   .loader
     vertical-align -1px
     margin-right 5px

--- a/src/components/dialogs/UserApiInfo.vue
+++ b/src/components/dialogs/UserApiInfo.vue
@@ -18,6 +18,7 @@ const dialogElement = ref(null)
 
 onMounted(() => {
   window.addEventListener('resize', updateDialogHeight)
+  updateAppApiKeys()
 })
 onBeforeUnmount(() => {
   window.removeEventListener('resize', updateDialogHeight)
@@ -73,6 +74,10 @@ const truncatedCensoredApiKey = (string, size) => {
   const censored = string.replace(/[^-]/g, 'x') // replace every character that isn't `-`
   return `${censored.substring(0, size)}…${string.substring(string.length - size, string.length)}`
 }
+const scopeDescription = (appApiKey) => {
+  const description = scope(appApiKey).description
+  return `Scope: ${description}`
+}
 
 // app api keys
 
@@ -81,32 +86,32 @@ const updateAppApiKeys = async () => {
   try {
     state.isLoading = true
     state.isError = false
-    // TODO should load from api onmount, state.error
-
-    // state.appApiKeys =
+    // TODO fetch from api
+    console.log('💐💐💐💐')
+    state.appApiKeys = [
+      {
+        name: 'Cool app this is a somethign lalala',
+        scope: 'read',
+        apiKey: '1209-3102938asl-dkfjlsa-kdjf',
+        color: 'red'
+      },
+      {
+        name: 'Whoa test',
+        scope: 'edit',
+        apiKey: 'ab2C-alsdkjfa23-dkfjlsa-123z',
+        color: 'blue'
+      }
+    ]
   } catch (error) {
     state.isError = true
   }
   state.isLoading = false
 }
-
-// STUB : replace w state.appApiKeys
-const appApiKeys = computed(() => {
-  return [
-    {
-      name: 'cool app',
-      scope: 'read',
-      apiKey: '1209-3102938asl-dkfjlsa-kdjf'
-    },
-    {
-      name: 'whoa test',
-      scope: 'edit',
-      apiKey: 'ab2C-alsdkjfa23-dkfjlsa-123z'
-    }
-  ]
-})
 const scope = (appApiKey) => {
-  return apiKeyScopes.find(scope => scope.name === appApiKey.name)
+  return apiKeyScopes.find(scope => scope.name === appApiKey.scope)
+}
+const truncate = (string) => {
+  return utils.truncated(string, 18)
 }
 
 </script>
@@ -146,14 +151,35 @@ dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop
     OfflineBadge
 
   //- app api keys
-  section
+  section.app-api-keys
     //- (v-if="!state.loading && state.appApiKeys.length")
 
-    //- results list ???
-    //- list app api keys
-    //- name, scope
-    //- key [copy]
-      [rotate] [remove] in AppApiKeyDetails
+    template(v-for="appApiKey in state.appApiKeys" :key="appApiKey.apiKey")
+      //- AppApiKeyListItem , can have indep state for confirmations
+      .row.title-row
+        div
+          .badge.circle-badge(:style="{ backgroundColor: appApiKey.color }")
+          span {{ truncate(appApiKey.name) }}
+          span.badge.secondary.scope-badge(:title="scopeDescription(appApiKey)")
+            img.icon.amount(src="@/assets/amount.svg")
+            span {{ scope(appApiKey).friendlyName }}
+      .row
+        span.badge.secondary.api-key-string(:data-apikey="appApiKey.apiKey")
+          img.icon.key(src="@/assets/key.svg")
+          code {{ truncatedCensoredApiKey(appApiKey.apiKey, 6) }}
+        .button-wrap
+          button.small-button(@click.left="copy($event, appApiKey.apiKey)" title="Copy App API Key")
+            img.icon.copy(src="@/assets/copy.svg")
+          button.small-button.danger(title="Rotate Key")
+            img.refresh.icon(src="@/assets/refresh.svg")
+          button.small-button.danger(title="Remove Key")
+            img.icon.remove(src="@/assets/remove.svg")
+      hr
+
+      //- list app api keys
+      //- color?? (opt-circle), name, scope
+      //- icon key [copy]
+      //- [rotate] [remove] in AppApiKeyDetails(:appApiKey="appApiKey")
       //- ^ confirm for both
 
     .badge.danger(v-if="state.error")
@@ -182,4 +208,16 @@ dialog.user-api-info
   .loader
     vertical-align -1px
     margin-right 5px
+  .app-api-keys
+    code
+      margin-right 0
+  .scope-badge
+    margin-left 6px
+  .circle-badge
+    border-radius 100px
+    min-width initial
+    min-height initial
+    display inline-block
+    width 12px
+    height 12px
 </style>

--- a/src/components/dialogs/UserApiInfo.vue
+++ b/src/components/dialogs/UserApiInfo.vue
@@ -57,7 +57,7 @@ const userApiKey = computed(() => userStore.apiKey)
 const copy = async (event, text) => {
   globalStore.clearNotificationsWithPosition()
   const position = utils.cursorPositionInPage(event)
-  position.x += -60
+  position.x += -40
   try {
     await navigator.clipboard.writeText(text)
     globalStore.addNotificationWithPosition({ message: 'Copied', position, type: 'success', layer: 'app', icon: 'checkmark' })
@@ -140,7 +140,7 @@ dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop
       .button-wrap
         button.small-button
           img.icon.add-icon(src="@/assets/add.svg")
-          span App Key
+          span App API Key
         //- AddAppApiKey
           //- name scope-picker
     OfflineBadge

--- a/src/components/dialogs/UserApiInfo.vue
+++ b/src/components/dialogs/UserApiInfo.vue
@@ -90,29 +90,25 @@ const truncatedApiKey = (string, size) => {
 
 // app api keys
 
-const updateAppApiKeys = async () => {
-  if (!globalStore.isOnline) { return }
+const createAppApiKey = async (body) => {
+  closeDialogs()
   try {
     state.isLoading = true
     state.isError = false
-    // TODO fetch from api
-    console.log('💐💐💐💐')
-    state.appApiKeys = [
-      {
-        id: '1a1',
-        name: 'Cool app this is a somethign lalala',
-        scope: 'read',
-        apiKey: '1209-3102938asl-dkfjlsa-kdjf',
-        color: 'red'
-      },
-      {
-        id: '2b',
-        name: 'Whoa test',
-        scope: 'edit',
-        apiKey: 'ab2C-alsdkjfa23-dkfjlsa-123z',
-        color: 'blue'
-      }
-    ]
+    state.appApiKeys.push(body)
+    await apiStore.createAppApiKey(body)
+  } catch (error) {
+    console.error('🚒 updateAppApiKey', error)
+    state.isError = true
+  }
+  state.isLoading = false
+}
+const updateAppApiKeys = async () => {
+  try {
+    state.isLoading = true
+    state.isError = false
+    state.appApiKeys = await apiStore.getAppApiKeys()
+    console.log('💐💐💐💐', state.appApiKeys)
   } catch (error) {
     console.error('🚒 updateAppApiKeys', error)
     state.isError = true
@@ -153,21 +149,6 @@ const deleteAppApiKey = async (update) => {
     state.isError = false
     state.appApiKeys = state.appApiKeys.filter(appApiKey => appApiKey.id !== update.id)
     await apiStore.deleteAppApiKey(update)
-  } catch (error) {
-    console.error('🚒 updateAppApiKey', error)
-    state.isError = true
-  }
-  state.isLoading = false
-}
-const createAppApiKey = (apiKey) => {
-  closeDialogs()
-  console.log('🍒🍒', apiKey)
-  // - color, name, scope-picker/list, id
-  try {
-    state.isLoading = true
-    state.isError = false
-    state.appApiKeys.push(apiKey)
-    // await apiStore.deleteAppApiKey(update)
   } catch (error) {
     console.error('🚒 updateAppApiKey', error)
     state.isError = true
@@ -215,7 +196,7 @@ dialog.user-api-info(
           span New
     OfflineBadge
   //- app api keys
-  section.app-api-keys(v-if="!state.loading && state.appApiKeys.length")
+  section.app-api-keys
     .badge.danger(v-if="state.error")
       span (シ_ _)シ Something went wrong, Please try again or contact support
     template(v-for="appApiKey in state.appApiKeys" :key="appApiKey.apiKey")

--- a/src/components/dialogs/UserApiInfo.vue
+++ b/src/components/dialogs/UserApiInfo.vue
@@ -4,15 +4,17 @@ import { reactive, computed, onMounted, onBeforeUnmount, watch, ref, nextTick } 
 import { useGlobalStore } from '@/stores/useGlobalStore'
 import { useUserStore } from '@/stores/useUserStore'
 import { useSpaceStore } from '@/stores/useSpaceStore'
+import { useApiStore } from '@/stores/useApiStore'
 
 import utils from '@/utils.js'
-import apiKeyScopes from '@/data/apiKeyScopes.js'
 import OfflineBadge from '@/components/OfflineBadge.vue'
 import Loader from '@/components/Loader.vue'
+import AppApiKeyListItem from '@/components/AppApiKeyListItem.vue'
 
 const globalStore = useGlobalStore()
 const userStore = useUserStore()
 const spaceStore = useSpaceStore()
+const apiStore = useApiStore()
 
 const dialogElement = ref(null)
 
@@ -22,7 +24,6 @@ onMounted(() => {
 })
 onBeforeUnmount(() => {
   window.removeEventListener('resize', updateDialogHeight)
-//   unsubscribe()
 })
 
 const props = defineProps({
@@ -68,15 +69,9 @@ const copy = async (event, text) => {
     globalStore.addNotificationWithPosition({ message: 'Copy Error', position, type: 'danger', layer: 'app', icon: 'cancel' })
   }
 }
-const truncatedCensoredApiKey = (string, size) => {
+const truncatedApiKey = (string, size) => {
   size = size || 10
-  // const string = userStore.apiKey
-  const censored = string.replace(/[^-]/g, 'x') // replace every character that isn't `-`
-  return `${censored.substring(0, size)}…${string.substring(string.length - size, string.length)}`
-}
-const scopeDescription = (appApiKey) => {
-  const description = scope(appApiKey).description
-  return `Scope: ${description}`
+  return `${string.substring(0, size)}…${string.substring(string.length - size, string.length)}`
 }
 
 // app api keys
@@ -107,13 +102,12 @@ const updateAppApiKeys = async () => {
   }
   state.isLoading = false
 }
-const scope = (appApiKey) => {
-  return apiKeyScopes.find(scope => scope.name === appApiKey.scope)
+const updateAppApiKey = async () => {
+  // apiStore.
 }
-const truncate = (string) => {
-  return utils.truncated(string, 18)
+const rotateAppApiKey = (appApiKey) => {
+  // const apiKey = self.crypto.randomUUID()
 }
-
 </script>
 
 <template lang="pug">
@@ -147,43 +141,15 @@ dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop
           img.icon.add-icon(src="@/assets/add.svg")
           span App API Key
         //- AddAppApiKey
-          //- name scope-picker
+          //- addGroup: color, name, scope-picker/list
     OfflineBadge
 
   //- app api keys
-  section.app-api-keys
-    //- (v-if="!state.loading && state.appApiKeys.length")
-
-    template(v-for="appApiKey in state.appApiKeys" :key="appApiKey.apiKey")
-      //- AppApiKeyListItem , can have indep state for confirmations
-      .row.title-row
-        div
-          .badge.circle-badge(:style="{ backgroundColor: appApiKey.color }")
-          span {{ truncate(appApiKey.name) }}
-          span.badge.secondary.scope-badge(:title="scopeDescription(appApiKey)")
-            img.icon.amount(src="@/assets/amount.svg")
-            span {{ scope(appApiKey).friendlyName }}
-      .row
-        span.badge.secondary.api-key-string(:data-apikey="appApiKey.apiKey")
-          img.icon.key(src="@/assets/key.svg")
-          code {{ truncatedCensoredApiKey(appApiKey.apiKey, 6) }}
-        .button-wrap
-          button.small-button(@click.left="copy($event, appApiKey.apiKey)" title="Copy App API Key")
-            img.icon.copy(src="@/assets/copy.svg")
-          button.small-button.danger(title="Rotate Key")
-            img.refresh.icon(src="@/assets/refresh.svg")
-          button.small-button.danger(title="Remove Key")
-            img.icon.remove(src="@/assets/remove.svg")
-      hr
-
-      //- list app api keys
-      //- color?? (opt-circle), name, scope
-      //- icon key [copy]
-      //- [rotate] [remove] in AppApiKeyDetails(:appApiKey="appApiKey")
-      //- ^ confirm for both
-
+  section.app-api-keys(v-if="!state.loading && state.appApiKeys.length")
     .badge.danger(v-if="state.error")
       span (シ_ _)シ Something went wrong, Please try again or contact support
+    template(v-for="appApiKey in state.appApiKeys" :key="appApiKey.apiKey")
+      AppApiKeyListItem(:appApiKey="appApiKey" @removeAppApiKey="removeAppApiKey" @rotateAppApiKey="rotateAppApiKey")
 
     //- user api key
     details
@@ -191,7 +157,7 @@ dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop
       section.subsection
         .row
           img.icon.key(src="@/assets/key.svg")
-          code.badge.secondary.api-key-string(:data-apikey="userApiKey") {{ truncatedCensoredApiKey(userApiKey, 9) }}
+          code.badge.secondary.api-key-string(:data-apikey="userApiKey") {{ truncatedApiKey(userApiKey, 9) }}
           .button-wrap
             button.small-button(@click.left="copy($event, userApiKey)" title="Copy User API Key")
               img.icon.copy(src="@/assets/copy.svg")

--- a/src/components/dialogs/UserApiInfo.vue
+++ b/src/components/dialogs/UserApiInfo.vue
@@ -41,7 +41,13 @@ const updateDialogHeight = async () => {
   state.dialogHeight = utils.elementHeight(element)
 }
 
+// data
+
 const userId = computed(() => userStore.id)
+const userApiKey = computed(() => userStore.apiKey)
+
+// output keys
+
 const copy = async (event, text) => {
   globalStore.clearNotificationsWithPosition()
   const position = utils.cursorPositionInPage(event)
@@ -55,16 +61,12 @@ const copy = async (event, text) => {
     globalStore.addNotificationWithPosition({ message: 'Copy Error', position, type: 'danger', layer: 'app', icon: 'cancel' })
   }
 }
-
-// output keys
-
-const apiKey = computed(() => userStore.apiKey)
-const truncatedCensoredApiKey = computed(() => {
-  const size = 10
-  const string = userStore.apiKey
+const truncatedCensoredApiKey = (string, size) => {
+  size = size || 10
+  // const string = userStore.apiKey
   const censored = string.replace(/[^-]/g, 'x') // replace every character that isn't `-`
   return `${censored.substring(0, size)}…${string.substring(string.length - size, string.length)}`
-})
+}
 
 // app api keys
 
@@ -114,7 +116,6 @@ dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop
   section.title-section
     .row.title-row
       span
-        img.icon.key(src="@/assets/key.svg")
         span API Keys
       .button-wrap
         button.small-button
@@ -136,9 +137,10 @@ dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop
       summary User API Key
       section.subsection
         .row
-          code.badge.secondary.api-key-string(:data-original="apiKey") {{ truncatedCensoredApiKey }}
+          img.icon.key(src="@/assets/key.svg")
+          code.badge.secondary.api-key-string(:data-apikey="userApiKey") {{ truncatedCensoredApiKey(userApiKey, 9) }}
           .button-wrap
-            button.small-button(@click.left="copy($event, apiKey)" title="Copy User API Key")
+            button.small-button(@click.left="copy($event, userApiKey)" title="Copy User API Key")
               img.icon.copy(src="@/assets/copy.svg")
         .row
           .badge.danger.copy-api-keys

--- a/src/components/dialogs/UserApiInfo.vue
+++ b/src/components/dialogs/UserApiInfo.vue
@@ -26,7 +26,6 @@ const props = defineProps({
 })
 const state = reactive({
   dialogHeight: null
-  // : false
 })
 
 watch(() => props.visible, (value, prevValue) => {
@@ -43,6 +42,27 @@ const updateDialogHeight = async () => {
 }
 
 const userId = computed(() => userStore.id)
+const copy = async (event, text) => {
+  globalStore.clearNotificationsWithPosition()
+  const position = utils.cursorPositionInPage(event)
+  position.x += -60
+  try {
+    await navigator.clipboard.writeText(text)
+    globalStore.addNotificationWithPosition({ message: 'Copied', position, type: 'success', layer: 'app', icon: 'checkmark' })
+    console.info('🍇 copied', text)
+  } catch (error) {
+    console.warn('🚑 copyText', error)
+    globalStore.addNotificationWithPosition({ message: 'Copy Error', position, type: 'danger', layer: 'app', icon: 'cancel' })
+  }
+}
+
+// delete = can edit and delete
+// edit
+// read
+// user
+
+// output keys
+
 const censor = (value) => {
   const uncensoredCharacters = 5
   const uncensored = value.slice(-uncensoredCharacters)
@@ -51,24 +71,12 @@ const censor = (value) => {
   return censored + uncensored
 }
 const censoredApiKey = computed(() => censor(userStore.apiKey))
-const copy = async (event, type) => {
-  globalStore.clearNotificationsWithPosition()
-  const position = utils.cursorPositionInPage(event)
-  position.x += -60
-  const apiKey = userStore.apiKey
-  let text = userId.value
-  if (type === 'apiKey') {
-    text = apiKey
-  }
-  try {
-    await navigator.clipboard.writeText(text)
-    globalStore.addNotificationWithPosition({ message: 'Copied', position, type: 'success', layer: 'app', icon: 'checkmark' })
-    console.info(`🍇 copied ${type}`)
-  } catch (error) {
-    console.warn('🚑 copyText', error)
-    globalStore.addNotificationWithPosition({ message: 'Copy Error', position, type: 'danger', layer: 'app', icon: 'cancel' })
-  }
-}
+const apiKey = computed(() => userStore.apiKey)
+const truncatedCensoredApiKey = computed(() => {
+  const string = userStore.apiKey
+  const censored = string.replace(/[^-]/g, 'x') // replace every character that isn't `-`
+  return `${censored.substring(0, 10)}…${string.substring(string.length - 10, string.length)}`
+})
 </script>
 
 <template lang="pug">
@@ -88,7 +96,7 @@ dialog.narrow.user-api-info(v-if="props.visible" :open="props.visible" @click.le
     .row
       code.badge.secondary {{ userId }}
       .button-wrap
-        button.small-button(@click.left="copy($event, 'userId')" title="Copy UserId")
+        button.small-button(@click.left="copy($event, userId)" title="Copy UserId")
           img.icon.copy(src="@/assets/copy.svg")
   //- api key
   section.title-section
@@ -100,9 +108,9 @@ dialog.narrow.user-api-info(v-if="props.visible" :open="props.visible" @click.le
       p
         span User API Key
     .row
-      code.badge.secondary {{ censoredApiKey }}
+      code.badge.secondary.api-key-string(:data-original="apiKey") {{ truncatedCensoredApiKey }}
       .button-wrap
-        button.small-button(@click.left="copy($event, 'apiKey')" title="Copy User API Key")
+        button.small-button(@click.left="copy($event, apiKey)" title="Copy User API Key")
           img.icon.copy(src="@/assets/copy.svg")
 
     .row

--- a/src/components/dialogs/UserApiInfo.vue
+++ b/src/components/dialogs/UserApiInfo.vue
@@ -181,6 +181,7 @@ dialog.user-api-info(
       .button-wrap
         button.small-button(@click.left="copy($event, userId)" title="Copy UserId")
           img.icon.copy(src="@/assets/copy.svg")
+
   //- api keys
   section.title-section
     .row.title-row
@@ -192,12 +193,14 @@ dialog.user-api-info(
           img.icon.add-icon(src="@/assets/add.svg")
           span New
     OfflineBadge
+
   //- app api keys
   section.app-api-keys
     .row.badge.danger(v-if="state.isError")
       span (シ_ _)シ Something went wrong, Please try again or contact support
     template(v-for="appApiKey in state.appApiKeys" :key="appApiKey.apiKey")
       AppApiKeyListItem(:appApiKey="appApiKey" @deleteAppApiKey="deleteAppApiKey" @rotateAppApiKey="rotateAppApiKey")
+
     //- user api key
     details
       summary User API Key

--- a/src/components/dialogs/UserApiInfo.vue
+++ b/src/components/dialogs/UserApiInfo.vue
@@ -56,31 +56,42 @@ const copy = async (event, text) => {
   }
 }
 
+// output keys
+
+const apiKey = computed(() => userStore.apiKey)
+const truncatedCensoredApiKey = computed(() => {
+  const size = 10
+  const string = userStore.apiKey
+  const censored = string.replace(/[^-]/g, 'x') // replace every character that isn't `-`
+  return `${censored.substring(0, size)}…${string.substring(string.length - size, string.length)}`
+})
+
+// app api keys
+
+const appApiKeys = computed(() => {
+  return [
+    {
+      name: 'cool app',
+      scope: 'read',
+      apiKey: '1209-3102938asl-dkfjlsa-kdjf'
+    },
+    {
+      name: 'whoa test',
+      scope: 'edit',
+      apiKey: 'ab2C-alsdkjfa23-dkfjlsa-123z'
+    }
+  ]
+})
+
 // delete = can edit and delete
 // edit
 // read
 // user
 
-// output keys
-
-const censor = (value) => {
-  const uncensoredCharacters = 5
-  const uncensored = value.slice(-uncensoredCharacters)
-  const toСensor = value.slice(0, -uncensoredCharacters)
-  const censored = toСensor.replace(/[^-]/g, 'x') // replace every character that isn't `-`
-  return censored + uncensored
-}
-const censoredApiKey = computed(() => censor(userStore.apiKey))
-const apiKey = computed(() => userStore.apiKey)
-const truncatedCensoredApiKey = computed(() => {
-  const string = userStore.apiKey
-  const censored = string.replace(/[^-]/g, 'x') // replace every character that isn't `-`
-  return `${censored.substring(0, 10)}…${string.substring(string.length - 10, string.length)}`
-})
 </script>
 
 <template lang="pug">
-dialog.narrow.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop ref="dialogElement" :style="{'max-height': state.dialogHeight + 'px'}")
+dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop ref="dialogElement" :style="{'max-height': state.dialogHeight + 'px'}")
   section.title-section
     .row.title-row
       span API
@@ -98,30 +109,46 @@ dialog.narrow.user-api-info(v-if="props.visible" :open="props.visible" @click.le
       .button-wrap
         button.small-button(@click.left="copy($event, userId)" title="Copy UserId")
           img.icon.copy(src="@/assets/copy.svg")
-  //- api key
+
+  //- api keys
   section.title-section
-    p
-      span API Keys
-
-  section
-    .row
-      p
-        span User API Key
-    .row
-      code.badge.secondary.api-key-string(:data-original="apiKey") {{ truncatedCensoredApiKey }}
+    .row.title-row
+      span
+        img.icon.key(src="@/assets/key.svg")
+        span API Keys
       .button-wrap
-        button.small-button(@click.left="copy($event, apiKey)" title="Copy User API Key")
-          img.icon.copy(src="@/assets/copy.svg")
+        button.small-button
+          img.icon.add-icon(src="@/assets/add.svg")
+          span App Key
+        //- AddAppApiKey
+          //- name scope-picker
 
-    .row
-      .badge.danger.copy-api-keys
-        p
-          img.icon.key(src="@/assets/key.svg")
-          span Your user API key has root permissions to your account, so keep it private.
+  //- results list ???
+  //- list app api keys
+  //- name, scope
+  //- key [copy]
+    [rotate] [remove] in AppApiKeyDetails
+    //- ^ confirm for both
+
+  //- show user api key
+  section
+    details
+      summary User API Key
+      section.subsection
+        .row
+          code.badge.secondary.api-key-string(:data-original="apiKey") {{ truncatedCensoredApiKey }}
+          .button-wrap
+            button.small-button(@click.left="copy($event, apiKey)" title="Copy User API Key")
+              img.icon.copy(src="@/assets/copy.svg")
+        .row
+          .badge.danger.copy-api-keys
+            p
+              span Your user API key has full root permissions to your account, so keep it private.
 </template>
 
 <style lang="stylus">
 dialog.user-api-info
+  left -18px
   overflow auto
   .copy-api-keys
     padding-top 4px

--- a/src/components/dialogs/UserApiInfo.vue
+++ b/src/components/dialogs/UserApiInfo.vue
@@ -86,26 +86,29 @@ dialog.narrow.user-api-info(v-if="props.visible" :open="props.visible" @click.le
     p User Id
     .row
       code.badge.secondary {{ userId }}
-    .row
       .button-wrap
-        button(@click.left="copy($event, 'userId')")
+        button.small-button(@click.left="copy($event, 'userId')" title="Copy UserId")
           img.icon.copy(src="@/assets/copy.svg")
-          span Copy UserId
   //- api key
+  section.title-section
+    p
+      span API Keys
+
   section
     .row
       p
-        img.icon.key(src="@/assets/key.svg")
-        span API Key
+        span User API Key
     .row
       code.badge.secondary {{ censoredApiKey }}
+      .button-wrap
+        button.small-button(@click.left="copy($event, 'apiKey')" title="Copy User API Key")
+          img.icon.copy(src="@/assets/copy.svg")
+
     .row
       .badge.danger.copy-api-keys
-        .button-wrap
-          button(@click.left="copy($event, 'apiKey')")
-            img.icon.copy(src="@/assets/copy.svg")
-            span Copy API Key
-        p Anyone with your key can read, edit, and remove your cards and spaces. So keep it private.
+        p
+          img.icon.key(src="@/assets/key.svg")
+          span Your user API key has root permissions to your account, so keep it private.
 </template>
 
 <style lang="stylus">

--- a/src/components/dialogs/UserApiInfo.vue
+++ b/src/components/dialogs/UserApiInfo.vue
@@ -21,7 +21,7 @@ const dialogElement = ref(null)
 
 onMounted(() => {
   window.addEventListener('resize', updateDialogHeight)
-  updateAppApiKeys()
+  getAppApiKeys()
 })
 onBeforeUnmount(() => {
   window.removeEventListener('resize', updateDialogHeight)
@@ -90,6 +90,17 @@ const truncatedApiKey = (string, size) => {
 
 // app api keys
 
+const getAppApiKeys = async () => {
+  try {
+    state.isLoading = true
+    state.isError = false
+    state.appApiKeys = await apiStore.getAppApiKeys()
+  } catch (error) {
+    console.error('🚒 getAppApiKeys', error)
+    state.isError = true
+  }
+  state.isLoading = false
+}
 const createAppApiKey = async (body) => {
   closeDialogs()
   try {
@@ -103,22 +114,16 @@ const createAppApiKey = async (body) => {
   }
   state.isLoading = false
 }
-const updateAppApiKeys = async () => {
+const rotateAppApiKey = async (appApiKey) => {
   try {
     state.isLoading = true
     state.isError = false
-    state.appApiKeys = await apiStore.getAppApiKeys()
-    console.log('💐💐💐💐', state.appApiKeys)
-  } catch (error) {
-    console.error('🚒 updateAppApiKeys', error)
-    state.isError = true
-  }
-  state.isLoading = false
-}
-const updateAppApiKey = async (update) => {
-  try {
-    state.isLoading = true
-    state.isError = false
+    const apiKey = self.crypto.randomUUID()
+    const update = {
+      id: appApiKey.id,
+      userId: userId.value,
+      apiKey
+    }
     state.appApiKeys = state.appApiKeys.map(appApiKey => {
       if (appApiKey.id === update.id) {
         const keys = Object.keys(update)
@@ -128,20 +133,12 @@ const updateAppApiKey = async (update) => {
       }
       return appApiKey
     })
-    await apiStore.updateAppApiKey(update)
+    await apiStore.rotateAppApiKey(update)
   } catch (error) {
-    console.error('🚒 updateAppApiKey', error)
+    console.error('🚒 rotateAppApiKey', error)
     state.isError = true
   }
   state.isLoading = false
-}
-const rotateAppApiKey = (appApiKey) => {
-  const apiKey = self.crypto.randomUUID()
-  const update = {
-    id: appApiKey.id,
-    apiKey
-  }
-  updateAppApiKey(update)
 }
 const deleteAppApiKey = async (update) => {
   try {
@@ -150,7 +147,7 @@ const deleteAppApiKey = async (update) => {
     state.appApiKeys = state.appApiKeys.filter(appApiKey => appApiKey.id !== update.id)
     await apiStore.deleteAppApiKey(update)
   } catch (error) {
-    console.error('🚒 updateAppApiKey', error)
+    console.error('🚒 deleteAppApiKey', error)
     state.isError = true
   }
   state.isLoading = false
@@ -197,7 +194,7 @@ dialog.user-api-info(
     OfflineBadge
   //- app api keys
   section.app-api-keys
-    .badge.danger(v-if="state.error")
+    .row.badge.danger(v-if="state.isError")
       span (シ_ _)シ Something went wrong, Please try again or contact support
     template(v-for="appApiKey in state.appApiKeys" :key="appApiKey.apiKey")
       AppApiKeyListItem(:appApiKey="appApiKey" @deleteAppApiKey="deleteAppApiKey" @rotateAppApiKey="rotateAppApiKey")

--- a/src/components/dialogs/UserApiInfo.vue
+++ b/src/components/dialogs/UserApiInfo.vue
@@ -10,6 +10,7 @@ import utils from '@/utils.js'
 import OfflineBadge from '@/components/OfflineBadge.vue'
 import Loader from '@/components/Loader.vue'
 import AppApiKeyListItem from '@/components/AppApiKeyListItem.vue'
+import AddAppApiKey from '@/components/dialogs/AddAppApiKey.vue'
 
 const globalStore = useGlobalStore()
 const userStore = useUserStore()
@@ -33,7 +34,8 @@ const state = reactive({
   dialogHeight: null,
   isLoading: false,
   isError: false,
-  appApiKeys: []
+  appApiKeys: [],
+  addAppApiKeyIsVisible: false
 })
 
 watch(() => props.visible, (value, prevValue) => {
@@ -47,6 +49,15 @@ const updateDialogHeight = async () => {
   await nextTick()
   const element = dialogElement.value
   state.dialogHeight = utils.elementHeight(element)
+}
+const closeDialogs = () => {
+  state.addAppApiKeyIsVisible = false
+}
+
+const toggleAddAppApiKeyIsVisible = () => {
+  const value = !state.addAppApiKeyIsVisible
+  closeDialogs()
+  state.addAppApiKeyIsVisible = value
 }
 
 // data
@@ -145,10 +156,13 @@ const deleteAppApiKey = async (update) => {
   }
   state.isLoading = false
 }
+const createAppApiKey = (apiKey) => {
+  // - color, name, scope-picker/list, id
+}
 </script>
 
 <template lang="pug">
-dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop ref="dialogElement" :style="{'max-height': state.dialogHeight + 'px'}")
+dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop="closeDialogs" ref="dialogElement" :style="{'max-height': state.dialogHeight + 'px'}")
   section.title-section
     .row.title-row
       span API
@@ -172,11 +186,10 @@ dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop
         Loader(:visible="state.isLoading" :isSmall="true")
         span API Keys
       .button-wrap
-        button.small-button
+        button.small-button(@click.stop="toggleAddAppApiKeyIsVisible" :class="{active: state.addAppApiKeyIsVisible}")
           img.icon.add-icon(src="@/assets/add.svg")
-          span App API Key
-        //- TODO AddAppApiKey
-          //- addGroup: color, name, scope-picker/list
+          span New
+        AddAppApiKey(:visible="state.addAppApiKeyIsVisible" @createAppApiKey="createAppApiKey")
     OfflineBadge
   //- app api keys
   section.app-api-keys(v-if="!state.loading && state.appApiKeys.length")

--- a/src/components/dialogs/UserApiInfo.vue
+++ b/src/components/dialogs/UserApiInfo.vue
@@ -54,6 +54,7 @@ const censoredApiKey = computed(() => censor(userStore.apiKey))
 const copy = async (event, type) => {
   globalStore.clearNotificationsWithPosition()
   const position = utils.cursorPositionInPage(event)
+  position.x += -60
   const apiKey = userStore.apiKey
   let text = userId.value
   if (type === 'apiKey') {

--- a/src/components/dialogs/UserApiInfo.vue
+++ b/src/components/dialogs/UserApiInfo.vue
@@ -85,12 +85,14 @@ const updateAppApiKeys = async () => {
     console.log('💐💐💐💐')
     state.appApiKeys = [
       {
+        id: '1a1',
         name: 'Cool app this is a somethign lalala',
         scope: 'read',
         apiKey: '1209-3102938asl-dkfjlsa-kdjf',
         color: 'red'
       },
       {
+        id: '2b',
         name: 'Whoa test',
         scope: 'edit',
         apiKey: 'ab2C-alsdkjfa23-dkfjlsa-123z',
@@ -98,15 +100,43 @@ const updateAppApiKeys = async () => {
       }
     ]
   } catch (error) {
+    console.error('🚒 updateAppApiKeys', error)
     state.isError = true
   }
   state.isLoading = false
 }
-const updateAppApiKey = async () => {
-  // apiStore.
+const updateAppApiKey = async (update) => {
+  try {
+    // TODO update state by id
+    state.isLoading = true
+    state.isError = false
+    // TODO await apiStore.
+  } catch (error) {
+    console.error('🚒 updateAppApiKey', error)
+    state.isError = true
+  }
+  state.isLoading = false
 }
 const rotateAppApiKey = (appApiKey) => {
-  // const apiKey = self.crypto.randomUUID()
+  const apiKey = self.crypto.randomUUID()
+  const update = {
+    id: appApiKey.id,
+    apiKey
+  }
+  updateAppApiKey(update)
+}
+const removeAppApiKey = async (appApiKey) => {
+  console.log('🍒')
+  try {
+    state.isLoading = true
+    state.isError = false
+    // TODO remove from state
+    // TODO await apiStore.removeAppApiKey
+  } catch (error) {
+    console.error('🚒 updateAppApiKey', error)
+    state.isError = true
+  }
+  state.isLoading = false
 }
 </script>
 
@@ -120,7 +150,6 @@ dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop
           button.small-button
             span API Docs{{' '}}
             img.icon.visit(src="@/assets/visit.svg")
-
   //- user id
   section
     p User Id
@@ -129,7 +158,6 @@ dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop
       .button-wrap
         button.small-button(@click.left="copy($event, userId)" title="Copy UserId")
           img.icon.copy(src="@/assets/copy.svg")
-
   //- api keys
   section.title-section
     .row.title-row
@@ -140,17 +168,15 @@ dialog.user-api-info(v-if="props.visible" :open="props.visible" @click.left.stop
         button.small-button
           img.icon.add-icon(src="@/assets/add.svg")
           span App API Key
-        //- AddAppApiKey
+        //- TODO AddAppApiKey
           //- addGroup: color, name, scope-picker/list
     OfflineBadge
-
   //- app api keys
   section.app-api-keys(v-if="!state.loading && state.appApiKeys.length")
     .badge.danger(v-if="state.error")
       span (シ_ _)シ Something went wrong, Please try again or contact support
     template(v-for="appApiKey in state.appApiKeys" :key="appApiKey.apiKey")
       AppApiKeyListItem(:appApiKey="appApiKey" @removeAppApiKey="removeAppApiKey" @rotateAppApiKey="rotateAppApiKey")
-
     //- user api key
     details
       summary User API Key
@@ -177,13 +203,4 @@ dialog.user-api-info
   .app-api-keys
     code
       margin-right 0
-  .scope-badge
-    margin-left 6px
-  .circle-badge
-    border-radius 100px
-    min-width initial
-    min-height initial
-    display inline-block
-    width 12px
-    height 12px
 </style>

--- a/src/components/dialogs/UserSettings.vue
+++ b/src/components/dialogs/UserSettings.vue
@@ -101,6 +101,7 @@ dialog.user-settings.narrow.is-pinnable(v-if="visible" :open="visible" ref="dial
     .segmented-buttons.settings-type-buttons
       button(@click="updateCurrentSettings('connections')" :class="{ active: currentSettingsIsConnections }")
         span Connections
+  .child-dialogs#settings-child-dialogs
 
   UserSettingsGeneral(:visible="currentSettingsIsGeneral")
   UserSettingsControls(:visible="currentSettingsIsControls")
@@ -135,4 +136,13 @@ dialog.user-settings
       button
         border-top-left-radius 0
         border-top-right-radius 0
+  .child-dialogs
+    dialog
+      top 30px
+      left 8px
+      right initial
+    dialog.user-api-info
+      left initial
+      right 8px
+
 </style>

--- a/src/components/dialogs/UserSettings.vue
+++ b/src/components/dialogs/UserSettings.vue
@@ -91,14 +91,14 @@ dialog.user-settings.narrow.is-pinnable(v-if="visible" :open="visible" ref="dial
       button.pin-button.small-button(:class="{active: userSettingsIsPinned}" @click.left="toggleUserSettingsIsPinned" title="Pin dialog")
         img.icon.pin(src="@/assets/pin.svg")
 
-    .segmented-buttons
+    .segmented-buttons.settings-type-buttons
       button(@click="updateCurrentSettings('general')" :class="{ active: currentSettingsIsGeneral }")
         span General
       button(@click="updateCurrentSettings('controls')" :class="{ active: currentSettingsIsControls }")
         span Controls
       button(@click="updateCurrentSettings('cards')" :class="{ active: currentSettingsIsCards }")
         span Cards
-    .segmented-buttons
+    .segmented-buttons.settings-type-buttons
       button(@click="updateCurrentSettings('connections')" :class="{ active: currentSettingsIsConnections }")
         span Connections
 
@@ -125,7 +125,7 @@ dialog.user-settings
       border-top 1px solid var(--primary-border)
       border-radius 0 !important
 
-  .segmented-buttons
+  .segmented-buttons.settings-type-buttons
     &:nth-child(even)
       button
         border-bottom-left-radius 0

--- a/src/components/dialogs/UserSettings.vue
+++ b/src/components/dialogs/UserSettings.vue
@@ -137,11 +137,11 @@ dialog.user-settings
         border-top-left-radius 0
         border-top-right-radius 0
   .child-dialogs
-    dialog
+    > dialog
       top 30px
       left 8px
       right initial
-    dialog.user-api-info
+    > dialog.user-api-info
       left initial
       right 8px
 

--- a/src/components/subsections/UserSettingsConnections.vue
+++ b/src/components/subsections/UserSettingsConnections.vue
@@ -34,7 +34,7 @@ const toggleShouldUseLastConnectionColor = () => {
     .row
       label(:class="{active: shouldUseLastConnectionColor}" @click.left.prevent="toggleShouldUseLastConnectionColor" @keydown.stop.enter="toggleShouldUseLastConnectionColor")
         input(type="checkbox" v-model="shouldUseLastConnectionColor")
-        .badge.badge-in-button(:style="{backgroundColor: lastColor}")
+        .badge.badge-in-button(v-if="lastColor" :style="{backgroundColor: lastColor}")
         span Use Last Color
     section.subsection
       p(v-if="shouldUseLastConnectionColor")

--- a/src/components/subsections/UserSettingsGeneral.vue
+++ b/src/components/subsections/UserSettingsGeneral.vue
@@ -60,7 +60,7 @@ const currentUser = computed(() => userStore.getUserAllState)
 const isModerator = computed(() => userStore.isModerator)
 const isSecureAppContextIOS = computed(() => consts.isSecureAppContextIOS)
 const updateViewportHeightIsShort = () => {
-  state.viewportHeightIsShort = globalStore.viewportHeight <= 650
+  state.viewportHeightIsShort = globalStore.viewportHeight <= 700
 }
 
 // dialog
@@ -78,7 +78,9 @@ const closeDialogs = () => {
 // child dialog state
 
 const toggleDeleteAccountConfirmationVisible = () => {
-  state.deleteAccountConfirmationVisible = !state.deleteAccountConfirmationVisible
+  const isVisible = state.deleteAccountConfirmationVisible
+  closeDialogs()
+  state.deleteAccountConfirmationVisible = !isVisible
 }
 const toggleUserBillingSettingsIsVisible = () => {
   const isVisible = state.userBillingSettingsIsVisible
@@ -230,5 +232,7 @@ const toggleIsDebugMode = () => {
       top 30px
       left 8px
       right initial
-
+    dialog.user-api-info
+      left initial
+      right 8px
 </style>

--- a/src/components/subsections/UserSettingsGeneral.vue
+++ b/src/components/subsections/UserSettingsGeneral.vue
@@ -9,7 +9,7 @@ import UserBillingSettings from '@/components/dialogs/UserBillingSettings.vue'
 import UserAccountSettings from '@/components/dialogs/UserAccountSettings.vue'
 import UserApiInfo from '@/components/dialogs/UserApiInfo.vue'
 import NotificationSettings from '@/components/dialogs/NotificationSettings.vue'
-import DeleteAllConfirmation from '@/components/dialogs/DeleteAllConfirmation.vue'
+import DeleteAccountConfirmation from '@/components/dialogs/DeleteAccountConfirmation.vue'
 import ThemeSettings from '@/components/dialogs/ThemeSettings.vue'
 import ThemeToggle from '@/components/ThemeToggle.vue'
 import ModeratorActions from '@/components/dialogs/ModeratorActions.vue'
@@ -23,6 +23,8 @@ const spaceStore = useSpaceStore()
 let unsubscribes
 
 onMounted(() => {
+  window.addEventListener('resize', updateViewportHeightIsShort)
+  updateViewportHeightIsShort()
   const globalActionUnsubscribe = globalStore.$onAction(
     ({ name, args }) => {
       if (name === 'triggerCloseChildDialogs') {
@@ -35,6 +37,7 @@ onMounted(() => {
   }
 })
 onBeforeUnmount(() => {
+  window.removeEventListener('resize', updateViewportHeightIsShort)
   unsubscribes()
 })
 
@@ -42,19 +45,23 @@ const props = defineProps({
   visible: Boolean
 })
 
-const currentUser = computed(() => userStore.getUserAllState)
-const isModerator = computed(() => userStore.isModerator)
-const isSecureAppContextIOS = computed(() => consts.isSecureAppContextIOS)
-
 const state = reactive({
   userBillingSettingsIsVisible: false,
   userAccountSettingsIsVisible: false,
-  deleteAllConfirmationVisible: false,
+  deleteAccountConfirmationVisible: false,
   userApiInfoIsVisible: false,
   moderatorActionsSettingsIsVisible: false,
   notificationSettingsIsVisible: false,
-  themeSettingsIsVisible: false
+  themeSettingsIsVisible: false,
+  viewportHeightIsShort: false
 })
+
+const currentUser = computed(() => userStore.getUserAllState)
+const isModerator = computed(() => userStore.isModerator)
+const isSecureAppContextIOS = computed(() => consts.isSecureAppContextIOS)
+const updateViewportHeightIsShort = () => {
+  state.viewportHeightIsShort = globalStore.viewportHeight <= 650
+}
 
 // dialog
 
@@ -65,13 +72,13 @@ const closeDialogs = () => {
   state.themeSettingsIsVisible = false
   state.userApiInfoIsVisible = false
   state.moderatorActionsSettingsIsVisible = false
-  state.deleteAllConfirmationVisible = false
+  state.deleteAccountConfirmationVisible = false
 }
 
 // child dialog state
 
-const toggleDeleteAllConfirmationVisible = () => {
-  state.deleteAllConfirmationVisible = !state.deleteAllConfirmationVisible
+const toggleDeleteAccountConfirmationVisible = () => {
+  state.deleteAccountConfirmationVisible = !state.deleteAccountConfirmationVisible
 }
 const toggleUserBillingSettingsIsVisible = () => {
   const isVisible = state.userBillingSettingsIsVisible
@@ -115,6 +122,8 @@ const toggleIsDebugMode = () => {
 
 <template lang="pug">
 .user-settings-general(v-if="visible" @click="closeDialogs")
+  .child-dialogs#child-dialogs
+  //- controls
   section
     //- Notifications
     .row
@@ -122,7 +131,12 @@ const toggleIsDebugMode = () => {
         button(@click.left.stop="toggleNotificationSettingsIsVisible" :class="{active: state.notificationSettingsIsVisible}")
           img.icon.mail(src="@/assets/mail.svg")
           span Notifications
-        NotificationSettings(:visible="state.notificationSettingsIsVisible")
+        template(v-if="state.viewportHeightIsShort")
+          teleport(to="#child-dialogs")
+            NotificationSettings(:visible="state.notificationSettingsIsVisible")
+        template(v-else)
+          NotificationSettings(:visible="state.notificationSettingsIsVisible")
+
     //- Theme and Colors
     .row
       .button-wrap
@@ -130,7 +144,12 @@ const toggleIsDebugMode = () => {
           ThemeToggle
           button(@click.left.stop="toggleThemeSettingsIsVisible" :class="{active: state.themeSettingsIsVisible}")
             span Theme Settings
-        ThemeSettings(:visible="state.themeSettingsIsVisible")
+        template(v-if="state.viewportHeightIsShort")
+          teleport(to="#child-dialogs")
+            ThemeSettings(:visible="state.themeSettingsIsVisible")
+        template(v-else)
+          ThemeSettings(:visible="state.themeSettingsIsVisible")
+
   //- Account Settings
   section
     .row
@@ -139,44 +158,77 @@ const toggleIsDebugMode = () => {
         button(@click.left.stop="toggleUserAccountSettingsIsVisible" :class="{active: state.userAccountSettingsIsVisible}")
           User(:user="currentUser" :isClickable="false" :hideYouLabel="true" :key="currentUser.id" :isSmall="true")
           span Account
-        UserAccountSettings(:visible="state.userAccountSettingsIsVisible")
+        template(v-if="state.viewportHeightIsShort")
+          teleport(to="#child-dialogs")
+            UserAccountSettings(:visible="state.userAccountSettingsIsVisible")
+        template(v-else)
+          UserAccountSettings(:visible="state.userAccountSettingsIsVisible")
+
       //- Billing
       .button-wrap
         button(@click.left.stop="toggleUserBillingSettingsIsVisible" :class="{active: state.userBillingSettingsIsVisible}")
           span(v-if="isSecureAppContextIOS") Billing
           span(v-else) Billing
-        UserBillingSettings(:visible="state.userBillingSettingsIsVisible")
+        template(v-if="state.viewportHeightIsShort")
+          teleport(to="#child-dialogs")
+            UserBillingSettings(:visible="state.userBillingSettingsIsVisible")
+        template(v-else)
+          UserBillingSettings(:visible="state.userBillingSettingsIsVisible")
+
+  //- Developer Info
   section
     .row
-      //- API/Developer Info
+      //- API
       .button-wrap
         button(@click.left.stop="toggleUserApiInfoIsVisible" :class="{active: state.userApiInfoIsVisible}")
           img.icon.key(src="@/assets/key.svg")
           span API
-        UserApiInfo(:visible="state.userApiInfoIsVisible")
+        template(v-if="state.viewportHeightIsShort")
+          teleport(to="#child-dialogs")
+            UserApiInfo(:visible="state.userApiInfoIsVisible")
+        template(v-else)
+          UserApiInfo(:visible="state.userApiInfoIsVisible")
+
+      //- debug
       .button-wrap
         label(:class="{active: isDebugMode}" @click.left.prevent="toggleIsDebugMode" @keydown.stop.enter="toggleIsDebugMode")
           input(type="checkbox" v-model="isDebugMode")
           span Debug Mode
+
     //- Moderator Actions
     .row(v-if="isModerator")
       .button-wrap
         button(@click.left.stop="toggleModeratorActionsSettingsIsVisible" :class="{active: state.moderatorActionsSettingsIsVisible}")
           span Moderator
-        ModeratorActions(:visible="state.moderatorActionsSettingsIsVisible")
+        template(v-if="state.viewportHeightIsShort")
+          teleport(to="#child-dialogs")
+            ModeratorActions(:visible="state.moderatorActionsSettingsIsVisible")
+        template(v-else)
+          ModeratorActions(:visible="state.moderatorActionsSettingsIsVisible")
+
   //- Delete Account
   section.delete-account
     .row
       .button-wrap
-        button.danger(@click.left.stop="toggleDeleteAllConfirmationVisible" :class="{ active: state.deleteAllConfirmationVisible }")
+        button.danger(@click.left.stop="toggleDeleteAccountConfirmationVisible" :class="{ active: state.deleteAccountConfirmationVisible }")
           img.icon(src="@/assets/remove.svg")
           span Delete Account
-        DeleteAllConfirmation(:visible="state.deleteAllConfirmationVisible" @toggleUserBillingSettingsIsVisible="toggleUserBillingSettingsIsVisible")
+        template(v-if="state.viewportHeightIsShort")
+          teleport(to="#child-dialogs")
+            DeleteAccountConfirmation(:visible="state.deleteAccountConfirmationVisible" @toggleUserBillingSettingsIsVisible="toggleUserBillingSettingsIsVisible")
+        template(v-else)
+          DeleteAccountConfirmation(:visible="state.deleteAccountConfirmationVisible" @toggleUserBillingSettingsIsVisible="toggleUserBillingSettingsIsVisible")
 </template>
 
 <style lang="stylus">
 .user-settings-general
-  section:not(.subsection)
+  > section:not(.subsection)
     border-top 1px solid var(--primary-border)
     border-radius 0 !important
+  .child-dialogs
+    dialog
+      top 30px
+      left 8px
+      right initial
+
 </style>

--- a/src/components/subsections/UserSettingsGeneral.vue
+++ b/src/components/subsections/UserSettingsGeneral.vue
@@ -56,6 +56,12 @@ const state = reactive({
   viewportHeightIsShort: false
 })
 
+watch(() => props.visible, (value, prevValue) => {
+  if (value) {
+    updateViewportHeightIsShort()
+  }
+})
+
 const currentUser = computed(() => userStore.getUserAllState)
 const isModerator = computed(() => userStore.isModerator)
 const isSecureAppContextIOS = computed(() => consts.isSecureAppContextIOS)
@@ -124,7 +130,6 @@ const toggleIsDebugMode = () => {
 
 <template lang="pug">
 .user-settings-general(v-if="visible" @click="closeDialogs")
-  .child-dialogs#child-dialogs
   //- controls
   section
     //- Notifications
@@ -134,7 +139,7 @@ const toggleIsDebugMode = () => {
           img.icon.mail(src="@/assets/mail.svg")
           span Notifications
         template(v-if="state.viewportHeightIsShort")
-          teleport(to="#child-dialogs")
+          teleport(to="#settings-child-dialogs")
             NotificationSettings(:visible="state.notificationSettingsIsVisible")
         template(v-else)
           NotificationSettings(:visible="state.notificationSettingsIsVisible")
@@ -147,7 +152,7 @@ const toggleIsDebugMode = () => {
           button(@click.left.stop="toggleThemeSettingsIsVisible" :class="{active: state.themeSettingsIsVisible}")
             span Theme Settings
         template(v-if="state.viewportHeightIsShort")
-          teleport(to="#child-dialogs")
+          teleport(to="#settings-child-dialogs")
             ThemeSettings(:visible="state.themeSettingsIsVisible")
         template(v-else)
           ThemeSettings(:visible="state.themeSettingsIsVisible")
@@ -161,7 +166,7 @@ const toggleIsDebugMode = () => {
           User(:user="currentUser" :isClickable="false" :hideYouLabel="true" :key="currentUser.id" :isSmall="true")
           span Account
         template(v-if="state.viewportHeightIsShort")
-          teleport(to="#child-dialogs")
+          teleport(to="#settings-child-dialogs")
             UserAccountSettings(:visible="state.userAccountSettingsIsVisible")
         template(v-else)
           UserAccountSettings(:visible="state.userAccountSettingsIsVisible")
@@ -172,7 +177,7 @@ const toggleIsDebugMode = () => {
           span(v-if="isSecureAppContextIOS") Billing
           span(v-else) Billing
         template(v-if="state.viewportHeightIsShort")
-          teleport(to="#child-dialogs")
+          teleport(to="#settings-child-dialogs")
             UserBillingSettings(:visible="state.userBillingSettingsIsVisible")
         template(v-else)
           UserBillingSettings(:visible="state.userBillingSettingsIsVisible")
@@ -186,7 +191,7 @@ const toggleIsDebugMode = () => {
           img.icon.key(src="@/assets/key.svg")
           span API
         template(v-if="state.viewportHeightIsShort")
-          teleport(to="#child-dialogs")
+          teleport(to="#settings-child-dialogs")
             UserApiInfo(:visible="state.userApiInfoIsVisible")
         template(v-else)
           UserApiInfo(:visible="state.userApiInfoIsVisible")
@@ -203,7 +208,7 @@ const toggleIsDebugMode = () => {
         button(@click.left.stop="toggleModeratorActionsSettingsIsVisible" :class="{active: state.moderatorActionsSettingsIsVisible}")
           span Moderator
         template(v-if="state.viewportHeightIsShort")
-          teleport(to="#child-dialogs")
+          teleport(to="#settings-child-dialogs")
             ModeratorActions(:visible="state.moderatorActionsSettingsIsVisible")
         template(v-else)
           ModeratorActions(:visible="state.moderatorActionsSettingsIsVisible")
@@ -216,7 +221,7 @@ const toggleIsDebugMode = () => {
           img.icon(src="@/assets/remove.svg")
           span Delete Account
         template(v-if="state.viewportHeightIsShort")
-          teleport(to="#child-dialogs")
+          teleport(to="#settings-child-dialogs")
             DeleteAccountConfirmation(:visible="state.deleteAccountConfirmationVisible" @toggleUserBillingSettingsIsVisible="toggleUserBillingSettingsIsVisible")
         template(v-else)
           DeleteAccountConfirmation(:visible="state.deleteAccountConfirmationVisible" @toggleUserBillingSettingsIsVisible="toggleUserBillingSettingsIsVisible")
@@ -227,12 +232,4 @@ const toggleIsDebugMode = () => {
   > section:not(.subsection)
     border-top 1px solid var(--primary-border)
     border-radius 0 !important
-  .child-dialogs
-    dialog
-      top 30px
-      left 8px
-      right initial
-    dialog.user-api-info
-      left initial
-      right 8px
 </style>

--- a/src/data/apiDocs.md
+++ b/src/data/apiDocs.md
@@ -21,7 +21,7 @@ App API Key | `App-Authorization` | Scope is either `user`, `read`, `edit`, or `
 
 App API Key Scopes | Description
 --- | ---
-`user` | Can only read <a href="#users" class="badge button-badge users">User</a>profile data
+`user` | Can only read <a href="#users" class="badge button-badge users">User</a> data
 `read` | Can read content (<a href="#users" class="badge button-badge users">User</a>, <a href="#spaces" class="badge button-badge spaces">Spaces</a>, <a href="#cards" class="badge button-badge cards">Cards</a>, etc.)
 `edit` | Can read and edit content
 `delete` | Can read, edit, and delete content

--- a/src/data/apiDocs.md
+++ b/src/data/apiDocs.md
@@ -7,13 +7,20 @@ You can auth requests with either your user or an app api key, both can be found
 Type | Header | Permissions | Description
 --- | --- | --- | ---
 User API Key | `Authorization` | Root | For personal projects only
-App API Key | `App-Authorization` | Scope is either `read`, `edit`, `delete` | For integrations, apps, and projects meant to be used by others
+App API Key | `App-Authorization` | Scope is either `user`, `read`, `edit`, or `delete` | For integrations, apps, and projects meant to be used by others
 
 <p class="badge danger">🙈 API Keys are secrets, so be sure to keep them safe. For safety, prefer keys with the narrowest scope possible.</p>
 
 A route that lists an **App Key** scope below can be called with an app API key that has that scope.
 
-<!-- (For testing, you can also use a query string (`?apiKey=`) but this is less secure and not recommended) -->
+### App API Key Scopes
+
+Scope | Description
+--- | ---
+`user` | ..
+`read` | ..
+`edit` | ..
+`delete` | ..
 
 ## Rate Limits
 

--- a/src/data/apiDocs.md
+++ b/src/data/apiDocs.md
@@ -6,25 +6,23 @@ You can auth requests with either your user or an app api key, both can be found
 
 Type | Header | Permissions | Description
 --- | --- | --- | ---
-User API Key | `Authorization` | Root | For personal projects only
+User API Key | `Authorization` | Root, be careful | For personal projects only
 App API Key | `App-Authorization` | Scope is either `user`, `read`, `edit`, or `delete` | For integrations, apps, and projects meant to be used by others
 
-<p class="badge danger">🙈 API Keys are secrets, so be sure to keep them safe. For safety, prefer keys with the narrowest scope possible.</p>
-
-A route that lists an **App Key** scope below can be called with an app API key that has that scope.
-
-### App API Key Scopes
-
-Scope | Description
+App API Key Scopes | Description
 --- | ---
-`user` | ..
-`read` | ..
-`edit` | ..
-`delete` | ..
+`user` | Can only read <a href="#users" class="badge button-badge users">User</a>profile data
+`read` | Can read content (spaces, cards, etc.)
+`edit` | Can read and edit content
+`delete` | Can read, edit, and delete content
+
+<p class="badge danger"><img class="icon key" src="@/assets/key.svg"/> API Keys are secrets, so be sure to keep them safe. For safety, prefer keys with the narrowest scope possible.</p>
 
 ## Rate Limits
 
 The API is limited to 5 requests per second. If you exceed this rate, you will receive a `429` response and will need to wait 30 seconds before subsequent requests will succeed.
+
+-------
 
 ## Routes and Attributes by Item Type
 
@@ -43,6 +41,7 @@ Method | Name | Description | Auth
 </div>
 </section>
 
+------
 
 <section class="section-wrap users">
 <a class="anchor" data-section="👯‍♀️" name="users"></a>
@@ -148,6 +147,8 @@ Name | Type | Description
 </div>
 </section>
 
+------
+
 <section class="section-wrap spaces">
 <a class="anchor" data-section="🍓" name="spaces"></a>
 <h2 class="badge spaces">Spaces</h2>
@@ -241,7 +242,7 @@ Name | Type | Description
 </div>
 </section>
 
-
+------
 
 <section class="section-wrap cards">
 <a class="anchor" data-section="🎑" name="cards"></a>
@@ -330,7 +331,7 @@ Name | Type | Description
 </div>
 </section>
 
-
+------
 
 <section class="section-wrap connections">
 <a class="anchor" data-section="🍆" name="connections"></a>
@@ -379,7 +380,7 @@ Name | Type | Description
 </div>
 </section>
 
-
+------
 
 <section class="section-wrap boxes">
 <a class="anchor" data-section="🍱" name="boxes"></a>
@@ -433,7 +434,7 @@ Name | Type | Description
 </div>
 </section>
 
-
+------
 
 <section class="section-wrap lists">
 <a class="anchor" data-section="🍱" name="lists"></a>
@@ -479,7 +480,7 @@ Name | Type | Description
 </div>
 </section>
 
-
+------
 
 <section class="section-wrap tags">
 <a class="anchor" data-section="🦚" name="tags"></a>
@@ -519,7 +520,7 @@ Name | Type | Description
 </div>
 </section>
 
-
+------
 
 <section class="section-wrap notifications">
 <a class="anchor" data-section="🛎" name="notifications"></a>
@@ -562,6 +563,7 @@ Name | Type | Description
 </div>
 </section>
 
+------
 
 <section class="section-wrap other">
 <a class="anchor" data-section="🛎" name="other"></a>

--- a/src/data/apiDocs.md
+++ b/src/data/apiDocs.md
@@ -162,7 +162,7 @@ Method | Path | Description | Scope
 `GET`    | <code class="spaces">/space/:spaceId/public-meta</code>    | Get public space info on non-private spaces                                                     | —
 `GET`    | <code class="spaces">/space/:spaceId/favorites</code>    | Get a list of users who have favorited the spaceId                                                | `read`
 `GET`    | <code class="spaces">/space/:spaceId/feed.json</code>    | `RSS feed` for cards recently created or updated in a space. Use `?apiKey=` for private spaces    | —
-`GET`    | <code class="spaces">/space/:spaceId/<br>removed-cards</code> | Get <a href="#cards" class="badge button-badge cards">Cards</a> removed in a space                         | `read`
+`GET`    | <code class="spaces">/space/:spaceId/removed-cards</code> | Get <a href="#cards" class="badge button-badge cards">Cards</a> removed in a space                         | `read`
 `GET`    | <code class="spaces">/space/explore-spaces</code>            | Get a list of recently updated public spaces which have been added to Explore. Sorted by date `showInExploreUpdatedAt` | —
 `GET`    | <code class="spaces">/space/explore-spaces/feed.json</code>  | `RSS feed` for new spaces added to Explore                                                    | —
 `GET`    | <code class="spaces">/space/live-spaces</code>           | Get a list of currently being edited spaces which are open or closed                              | —

--- a/src/data/apiDocs.md
+++ b/src/data/apiDocs.md
@@ -16,8 +16,8 @@ You can auth requests with either your user or an app api key, both can be found
 
 API Key Type | Header | Permissions | Description
 --- | --- | --- | ---
-User API Key | `Authorization` | Root, be careful | For personal projects only
-App API Key | `App-Authorization` | Scope is either `user`, `read`, `edit`, or `delete` | For integrations, apps, and projects meant to be used by others
+App API Key | `App-Authorization` | Scope is either `user`, `read`, `edit`, or `delete` | For projects, apps, and integrations
+User API Key | `Authorization` | Root, be careful | For legacy projects
 
 App API Key Scopes | Description
 --- | ---
@@ -43,8 +43,6 @@ The API is limited to 5 requests per second. If you exceed this rate, you will r
 Users are representations of any account on Kinopio. Users are created by the server when they sign up.
 
 <h3 class="badge users">User Routes</h3>
-
-Routes with Auth as `apiKey` mean that the Authorization header apiKey must match the requested user.
 
 <div class="table-wrap users routes-table-wrap">
 
@@ -150,10 +148,6 @@ Spaces are where your <a href="#cards" class="badge button-badge cards">Cards</a
 
 <h3 class="badge spaces">Space Routes</h3>
 
-Routes with Auth `canViewSpace` or `canEditSpace` requires that your Authorization apiKey belongs to a user with the permission to view or edit the space.
-
-The `closed` privacy state refers to `Public Read Only`.
-
 <div class="table-wrap spaces routes-table-wrap">
 
 Method | Path | Description | Scope
@@ -165,7 +159,7 @@ Method | Path | Description | Scope
 `GET`    | <code class="spaces">/space/:spaceId/removed-cards</code> | Get <a href="#cards" class="badge button-badge cards">Cards</a> removed in a space                         | `read`
 `GET`    | <code class="spaces">/space/explore-spaces</code>            | Get a list of recently updated public spaces which have been added to Explore. Sorted by date `showInExploreUpdatedAt` | —
 `GET`    | <code class="spaces">/space/explore-spaces/feed.json</code>  | `RSS feed` for new spaces added to Explore                                                    | —
-`GET`    | <code class="spaces">/space/live-spaces</code>           | Get a list of currently being edited spaces which are open or closed                              | —
+`GET`    | <code class="spaces">/space/live-spaces</code>           | Get a list of currently being edited spaces which are `open` or `closed` (Public Read Only)       | —
 `GET`    | <code class="spaces">/space/multiple?spaceIds=id1,id2</code> | Get info on multiple spaces, up to 60 spaceIds at a time                                      | `read`
 `GET`    | <code class="spaces">/space/public/multiple?spaceIds=id1,id2</code>        | Gets public info for multiple public spaces, up to 60 spaceIds at a time. | —
 `GET`    | <code class="spaces">/space/inbox</code>         | Get the current user's inbox space                                                                        | `read`
@@ -241,11 +235,9 @@ Name | Type | Description
 <a class="anchor" data-section="🎑" name="cards"></a>
 <h2 class="badge cards">Cards</h2>
 
-Cards are the building blocks of <a href="#spaces" class="badge spaces">Spaces</a>. They have `x`, `y`, and `z` positions and a `name`.
+Cards are the building blocks of <a href="#spaces" class="badge spaces">Spaces</a>. They have `x`, `y`, and `z` positions, `height`, `width`, and a `name`.
 
 <h3 class="badge cards">Cards Routes</h3>
-
-Routes with Auth `canEditSpace` requires that your Authorization apiKey belongs to a user with the permission to edit the space that the card belongs to.
 
 <div class="table-wrap cards routes-table-wrap">
 
@@ -330,11 +322,9 @@ Name | Type | Description
 <a class="anchor" data-section="🍆" name="connections"></a>
 <h2 class="badge connections">Connections</h2>
 
-Connections are the lines that connect cards together.
+Connections are lines that visually connect a `startItemId` to an `endItemId`.
 
 <h3 class="badge connections">Connection Routes</h3>
-
-Routes with Auth `canEditSpace` requires that your Authorization apiKey belongs to a user with the permission to edit the space that the connection belongs to.
 
 <div class="table-wrap connections routes-table-wrap">
 
@@ -382,8 +372,6 @@ Name | Type | Description
 Boxes are items used by users to contain or organize cards in a space. They can be named, colored, and positioned
 
 <h3 class="badge boxes">Box Routes</h3>
-
-Routes with Auth `canEditSpace` requires that your Authorization apiKey belongs to a user with the permission to edit the space that the box belongs to.
 
 <div class="table-wrap boxes routes-table-wrap">
 
@@ -433,11 +421,9 @@ Name | Type | Description
 <a class="anchor" data-section="🍱" name="lists"></a>
 <h2 class="badge lists">Lists</h2>
 
-Lists are items used by users to vertically contain and organize cards in a space. They can be named, colored, and positioned. <a href="#cards" class="badge button-badge cards">Cards</a> that belong to lists have a `listId`, and `listPositionIndex`.
+Lists are items used by users to vertically contain and organize <a href="#cards" class="badge button-badge cards">Cards</a>in a space. They can be named, colored, and positioned. Cards that belong to lists have a `listId`, and `listPositionIndex`.
 
 <h3 class="badge lists">List Routes</h3>
-
-Routes with Auth `canEditSpace` requires that your Authorization apiKey belongs to a user with the permission to edit the space that the list belongs to.
 
 <div class="table-wrap lists routes-table-wrap">
 
@@ -479,11 +465,9 @@ Name | Type | Description
 <a class="anchor" data-section="🦚" name="tags"></a>
 <h2 class="badge tags">Tags</h2>
 
-Each tag you add to a card is considered a seperate entity. So if you have two cards which both have the tag [[balloon]], this is two tag entities both named 'balloon', with different cardIds.
+Each tag you add to a card is considered a seperate entity. So if you have multiple <a href="#cards" class="badge button-badge cards">Cards</a>which both have the tag `[[balloon]]` in their `name`, you'll have multiple tag objects named `'balloon'` with different cardIds.
 
 <h3 class="badge tags">Tags Routes</h3>
-
-Routes with Auth `canEditSpace` requires that your Authorization apiKey belongs to a user with the permission to edit the space that the tag belongs to.
 
 <div class="table-wrap tags routes-table-wrap">
 
@@ -523,8 +507,6 @@ Notifications are created when another user adds a card in a space that you're a
 
 <h3 class="badge notifications">Notifications Routes</h3>
 
-Routes with Auth as `apiKey` mean that the Authorization header apiKey must match the requested user.
-
 <div class="table-wrap notifications routes-table-wrap">
 
 Method | Path | Description | Scope
@@ -562,7 +544,7 @@ Name | Type | Description
 <a class="anchor" data-section="🛎" name="other"></a>
 <h2 class="badge other">Other</h2>
 
-Other routes used by the kinopio-client app, which you can also use in your integrations
+Other routes used by the `kinopio-client` app, which you can also use in your integrations
 
 <h3 class="badge other">other Routes</h3>
 

--- a/src/data/apiDocs.md
+++ b/src/data/apiDocs.md
@@ -2,12 +2,14 @@ The Kinopio API is used to find, save, and update the spaces of signed up users.
 
 ## Authentication
 
-Kinopio has two kinds of API keys:
+You can auth requests with either your user or an app api key, both can be found in `User → Settings → Account → API`.
 
-- **User API key** gives full access to your account, just like being signed in. Send it in the `Authorization` header. Get it in the app through `User → Settings → Account → API`.
-- **App API key** is a key you generate with a limited set of scopes, for building integrations or sharing access without handing over your whole account. Send it in the `app-authorization` header.
+Type | Header | Permissions | Description
+--- | --- | --- | ---
+User API Key | `Authorization` | Root | For personal projects only
+App API Key | `App-Authorization` | Scope is either `read`, `edit`, `delete` | For integrations, apps, and projects meant to be used by others
 
-<p class="badge danger">🙈 Both keys are secrets, so be sure to keep them safe. Prefer an app API key with the narrowest scopes for anything you don't fully control.</p>
+<p class="badge danger">🙈 API Keys are secrets, so be sure to keep them safe. For safety, prefer keys with the narrowest scope possible.</p>
 
 A route that lists an **App Key** scope below can be called with an app API key that has that scope.
 

--- a/src/data/apiDocs.md
+++ b/src/data/apiDocs.md
@@ -2,11 +2,14 @@ The Kinopio API is used to find, save, and update the spaces of signed up users.
 
 ## Authentication
 
-Kinopio uses token-based authentication using your user `apiKey`. You can get your apiKey in the app through `User → Settings → Account → API`.
+Kinopio has two kinds of API keys:
 
-Use your apiKey in the `Authorization` header of each request.
+- **User API key** gives full access to your account, just like being signed in. Send it in the `Authorization` header. Get it in the app through `User → Settings → Account → API`.
+- **App API key** is a key you generate with a limited set of scopes, for building integrations or sharing access without handing over your whole account. Send it in the `app-authorization` header.
 
-<p class="badge danger">🙈 Your API key carries the same privileges as your user account, so be sure to keep it secret!</p>
+<p class="badge danger">🙈 Both keys are secrets, so be sure to keep them safe. Prefer an app API key with the narrowest scopes for anything you don't fully control.</p>
+
+A route that lists an **App Key** scope below can be called with an app API key that has that scope.
 
 <!-- (For testing, you can also use a query string (`?apiKey=`) but this is less secure and not recommended) -->
 
@@ -44,25 +47,25 @@ Routes with Auth as `apiKey` mean that the Authorization header apiKey must matc
 
 <div class="table-wrap users routes-table-wrap">
 
-Method | Path | Description | Auth
---- | --- | --- | ---
-`GET`   | <code class="users">/user/public/:userId</code>         | Gets public info on a user                                                                                                                                | None
-`GET`   | <code class="users">/user/public/explore-spaces/:userId</code>   | The a list of spaces with `showInExplore: true` created by the user                                                          | None
-`GET`   | <code class="users">/user/hidden-spaces</code>          | Get hidden spaces for the authenticating user                                                         | `apiKey`
-`GET`   | <code class="users">/user/public/multiple?userIds=id1,id2</code>        | Gets public info for multiple userIds, up to 60 userIds at a time                                      | None
-`GET`   | <code class="users">/user</code>                        | Get all info on the authenticating user                                                                                                                   | `apiKey`
-`GET`   | <code class="users">/user/favorite-spaces</code>        | Get favorite spaces for the authenticating user. Favorited spaces which have unread updates will have `isEdited: true`                      | `apiKey`
-`GET`   | <code class="users">/user/favorite-users</code>         | Get favorite users for the authenticating user                                                          | `apiKey`
-`GET`   | <code class="users">/user/favorite-colors</code>        | Get favorite colors for the authenticating user                                                         | `apiKey`
-`GET`   | <code class="users">/user/spaces</code>                 | Get a list of the user's <a href="#spaces" class="badge button-badge spaces">Spaces</a>. Use `/user/group-spaces` for spaces created by other members of groups they belong to           | `apiKey`
-`GET`   | <code class="users">/user/groups</code>                 | Get a list of the user's groups. Their role in each group (`member` or `admin`) is inside the `groupUser` object                                    | `apiKey`
-`GET`   | <code class="users">/user/group-spaces</code>           | Get a list of the user's group <a href="#spaces" class="badge button-badge spaces">Spaces</a> created by other members of groups they belong to                                          | `apiKey`
-`GET`   | <code class="users">/user/template-spaces</code>        | Get a list of the user's template <a href="#spaces" class="badge button-badge spaces">Spaces</a>. These include template spaces you made or are a collaborator in                        | `apiKey`
-`GET`   | <code class="users">/user/removed-spaces</code>         | Get <a href="#spaces" class="badge button-badge spaces">Spaces</a> removed by the authenticating user                                                                  | `apiKey`
-`GET`   | <code class="users">/user/inbox-space</code>            | Get info on the user's `Inbox` space. whether a space is an inbox or not is based on name only, so it's possible to have multiple `Inbox` spaces, but only one the most recently updated Inbox will be returned | `apiKey`
-`GET`   | <code class="users">/user/tags</code>                   | Get a list of the last edited <a href="#tags" class="badge button-badge tags">Tags</a> in your spaces                                                                  | `apiKey`
-`GET`   | <code class="users">/user/todos</code>                  | Get todo cards and boxes (item names start with `[]`, `[ ]`, or `[x]`), grouped by space                                                                            | `apiKey`
-`PATCH` | <code class="users">/user</code>                        | Update the user based on an object body with updated user attributes. You can't patch `apiKey`, `password`, `emailIsVerified`, or `email`       | `apiKey`
+Method | Path | Description | Auth | App Key
+--- | --- | --- | --- | ---
+`GET`   | <code class="users">/user/public/:userId</code>         | Gets public info on a user                                                                                                                                | None | —
+`GET`   | <code class="users">/user/public/explore-spaces/:userId</code>   | The a list of spaces with `showInExplore: true` created by the user                                                          | None | —
+`GET`   | <code class="users">/user/hidden-spaces</code>          | Get hidden spaces for the authenticating user                                                         | `apiKey` | `read`
+`GET`   | <code class="users">/user/public/multiple?userIds=id1,id2</code>        | Gets public info for multiple userIds, up to 60 userIds at a time                                      | None | —
+`GET`   | <code class="users">/user</code>                        | Get all info on the authenticating user                                                                                                                   | `apiKey` | `user`
+`GET`   | <code class="users">/user/favorite-spaces</code>        | Get favorite spaces for the authenticating user. Favorited spaces which have unread updates will have `isEdited: true`                      | `apiKey` | `read`
+`GET`   | <code class="users">/user/favorite-users</code>         | Get favorite users for the authenticating user                                                          | `apiKey` | `read`
+`GET`   | <code class="users">/user/favorite-colors</code>        | Get favorite colors for the authenticating user                                                         | `apiKey` | `read`
+`GET`   | <code class="users">/user/spaces</code>                 | Get a list of the user's <a href="#spaces" class="badge button-badge spaces">Spaces</a>. Use `/user/group-spaces` for spaces created by other members of groups they belong to           | `apiKey` | `read`
+`GET`   | <code class="users">/user/groups</code>                 | Get a list of the user's groups. Their role in each group (`member` or `admin`) is inside the `groupUser` object                                    | `apiKey` | `read`
+`GET`   | <code class="users">/user/group-spaces</code>           | Get a list of the user's group <a href="#spaces" class="badge button-badge spaces">Spaces</a> created by other members of groups they belong to                                          | `apiKey` | `read`
+`GET`   | <code class="users">/user/template-spaces</code>        | Get a list of the user's template <a href="#spaces" class="badge button-badge spaces">Spaces</a>. These include template spaces you made or are a collaborator in                        | `apiKey` | `read`
+`GET`   | <code class="users">/user/removed-spaces</code>         | Get <a href="#spaces" class="badge button-badge spaces">Spaces</a> removed by the authenticating user                                                                  | `apiKey` | `read`
+`GET`   | <code class="users">/user/inbox-space</code>            | Get info on the user's `Inbox` space. whether a space is an inbox or not is based on name only, so it's possible to have multiple `Inbox` spaces, but only one the most recently updated Inbox will be returned | `apiKey` | `read`
+`GET`   | <code class="users">/user/tags</code>                   | Get a list of the last edited <a href="#tags" class="badge button-badge tags">Tags</a> in your spaces                                                                  | `apiKey` | `read`
+`GET`   | <code class="users">/user/todos</code>                  | Get todo cards and boxes (item names start with `[]`, `[ ]`, or `[x]`), grouped by space                                                                            | `apiKey` | `read`
+`PATCH` | <code class="users">/user</code>                        | Update the user based on an object body with updated user attributes. You can't patch `apiKey`, `password`, `emailIsVerified`, or `email`       | `apiKey` | `edit`
 
 </div>
 
@@ -150,29 +153,29 @@ The `closed` privacy state refers to `Public Read Only`.
 
 <div class="table-wrap spaces routes-table-wrap">
 
-Method | Path | Description | Auth
---- | --- | --- | ---
-`GET`    | <code class="spaces">/space/:spaceId</code>              | Get info on a space by id. Use `?textOnly=true` for card names only                               | `canViewSpace`
-`GET`    | <code class="spaces">/space/:spaceId/public-meta</code>    | Get public space info on non-private spaces                                                     | None
-`GET`    | <code class="spaces">/space/:spaceId/favorites</code>    | Get a list of users who have favorited the spaceId                                                | None
-`GET`    | <code class="spaces">/space/:spaceId/feed.json</code>    | `RSS feed` for cards recently created or updated in a space. Use `?apiKey=` for private spaces    | `canViewSpace`
-`GET`    | <code class="spaces">/space/:spaceId/<br>removedCards</code> | Get <a href="#cards" class="badge button-badge cards">Cards</a> removed in a space                         | `canEditSpace`
-`GET`    | <code class="spaces">/space/explore-spaces</code>            | Get a list of recently updated public spaces which have been added to Explore. Sorted by date `showInExploreUpdatedAt` | None
-`GET`    | <code class="spaces">/space/explore-spaces/feed.json</code>  | `RSS feed` for new spaces added to Explore                                                    | None
-`GET`    | <code class="spaces">/space/live-spaces</code>           | Get a list of currently being edited spaces which are open or closed                              | None
-`GET`    | <code class="spaces">/space/multiple?spaceIds=id1,id2</code> | Get info on multiple spaces, up to 60 spaceIds at a time                                      | `canViewSpace`
-`GET`    | <code class="spaces">/space/public/multiple?spaceIds=id1,id2</code>        | Gets public info for multiple public spaces, up to 60 spaceIds at a time.          None
-`GET`    | <code class="spaces">/space/inbox</code>         | Get the current user's inbox space                                                                        | `apiKey`
-`GET`    | <code class="spaces">/space/everyones-spaces</code>            | Get a list of recent public spaces sorted by date `createdAt`                               | None
-`GET`    | <code class="spaces">/space/everyones-spaces/feed.json</code>  | `RSS feed` for recent public spaces                                                         | None
-`GET`    | <code class="spaces">/space/date-image</code>        | Get the image url for today's date card image                                                         | None
-`POST`   | <code class="spaces">/space</code>                       | Create a new space(s) from object(s) in request body. The owner will be the apiKey user           | `apiKey`
-`POST`   | <code class="spaces">/space/search-explore-space</code>   | Get all `showInExplore` spaces based on space name. Body object must contain `query`. Searches are not case-insensitive           | None
-`PATCH`  | <code class="spaces">/space</code>                       | Update space(s) from object(s) in request body                                                    | `canEditSpace`
-`PATCH`  | <code class="spaces">/space/restore</code>               | Restore removed space(s)  from object(s) in request body                                          | `canEditSpace`
-`DELETE` | <code class="spaces">/space</code>                       | Remove space(s) specified in request body                                                         | `canEditSpace`
-`DELETE` | <code class="spaces">/space/permanent</code>             | Permanently remove space(s) specified in request body                                             | `canEditSpace`
-`DELETE` | <code class="spaces">/space/collaborator</code>          | Removes collaborator user from space. Request Body Keys: `spaceId`, `userId`                      | `canEditSpace`
+Method | Path | Description | Auth | App Key
+--- | --- | --- | --- | ---
+`GET`    | <code class="spaces">/space/:spaceId</code>              | Get info on a space by id. Use `?textOnly=true` for card names only                               | `canViewSpace` | `read`
+`GET`    | <code class="spaces">/space/:spaceId/public-meta</code>    | Get public space info on non-private spaces                                                     | None | —
+`GET`    | <code class="spaces">/space/:spaceId/favorites</code>    | Get a list of users who have favorited the spaceId                                                | None | `read`
+`GET`    | <code class="spaces">/space/:spaceId/feed.json</code>    | `RSS feed` for cards recently created or updated in a space. Use `?apiKey=` for private spaces    | `canViewSpace` | —
+`GET`    | <code class="spaces">/space/:spaceId/<br>removed-cards</code> | Get <a href="#cards" class="badge button-badge cards">Cards</a> removed in a space                         | `canEditSpace` | `read`
+`GET`    | <code class="spaces">/space/explore-spaces</code>            | Get a list of recently updated public spaces which have been added to Explore. Sorted by date `showInExploreUpdatedAt` | None | —
+`GET`    | <code class="spaces">/space/explore-spaces/feed.json</code>  | `RSS feed` for new spaces added to Explore                                                    | None | —
+`GET`    | <code class="spaces">/space/live-spaces</code>           | Get a list of currently being edited spaces which are open or closed                              | None | —
+`GET`    | <code class="spaces">/space/multiple?spaceIds=id1,id2</code> | Get info on multiple spaces, up to 60 spaceIds at a time                                      | `canViewSpace` | `read`
+`GET`    | <code class="spaces">/space/public/multiple?spaceIds=id1,id2</code>        | Gets public info for multiple public spaces, up to 60 spaceIds at a time. | None | —
+`GET`    | <code class="spaces">/space/inbox</code>         | Get the current user's inbox space                                                                        | `apiKey` | `read`
+`GET`    | <code class="spaces">/space/everyone-spaces</code>            | Get a list of recent public spaces sorted by date `createdAt`                               | None | —
+`GET`    | <code class="spaces">/space/everyone-spaces/feed.json</code>  | `RSS feed` for recent public spaces                                                         | None | —
+`GET`    | <code class="spaces">/space/date-image</code>        | Get the image url for today's date card image                                                         | None | —
+`POST`   | <code class="spaces">/space</code>                       | Create a new space(s) from object(s) in request body. The owner will be the apiKey user           | `apiKey` | `edit`
+`POST`   | <code class="spaces">/space/search-explore-spaces</code>   | Get all `showInExplore` spaces based on space name. Body object must contain `query`. Searches are not case-insensitive           | None | —
+`PATCH`  | <code class="spaces">/space</code>                       | Update space(s) from object(s) in request body                                                    | `canEditSpace` | `edit`
+`PATCH`  | <code class="spaces">/space/restore/:spaceId</code>               | Restore removed space(s)  from object(s) in request body                                          | `canEditSpace` | `edit`
+`DELETE` | <code class="spaces">/space</code>                       | Remove space(s) specified in request body                                                         | `canEditSpace` | `delete`
+`DELETE` | <code class="spaces">/space/permanent</code>             | Permanently remove space(s) specified in request body                                             | `canEditSpace` | `delete`
+`DELETE` | <code class="spaces">/space/collaborator</code>          | Removes collaborator user from space. Request Body Keys: `spaceId`, `userId`                      | `canEditSpace` | `edit`
 
 </div>
 
@@ -243,24 +246,24 @@ Routes with Auth `canEditSpace` requires that your Authorization apiKey belongs 
 
 <div class="table-wrap cards routes-table-wrap">
 
-Method | Path | Description | Auth
---- | --- | --- | ---
-`GET`     | <code class="cards">/card/:cardId</code>                | Get info on a card                                                                                                                                                                  | `canViewSpace`
-`GET`     | <code class="cards">/card/multiple?cardIds=id1,id2</code> | Get info on multiple cards, up to 60 cardIds at a time                                                                                                                    | `canViewSpace`
-`GET`     | <code class="cards">/card/by-tag-name/:tagName</code>   | Get all cards with tag matching tagName in your <a href="#spaces" class="badge button-badge spaces">Spaces</a>                                                                                   | `apiKey`
-`GET`     | <code class="cards">/card/by-link-to-space/:spaceId</code>   | Get the cards and <a href="#spaces" class="badge button-badge spaces">Spaces</a> where `linkToSpaceId` is `spaceId`. Will only return spaces that the user can view                         | `apiKey and canViewSpace`
-`POST`    | <code class="cards">/card/search</code>                 | Get all cards that match a query. Body object must contain `query`. Only matches cards created by the user. Does not return removed cards, or cards from removed spaces. Searches are not case-insensitive                                       | `apiKey`
-`POST`    | <code class="cards">/card</code>                        | Create card from object in request body. Body object must contain `spaceId` and `name`. If not included, `x`, `y`, `z` will be positioned near the top left of the space, in a cascade pattern to prevent overlaps | `canEditSpace`
-`POST`    | <code class="cards">/card/to-inbox</code>               | Create card saved to the user's `Inbox` space from object in request body and . Body object must contain `name`. Will return `404` if the user does not already have an `Inbox` space. Positioning works just like `POST /card`        | `canEditSpace`
-`POST`    | <code class="cards">/card/multiple</code>               | Creates multiple cards from an array of objects in request body. Works just like `POST /card`                                                                                | `canEditSpace`
-`POST`    | <code class="cards">/card/list</code>                   | Add card to a <a href="#lists" class="badge button-badge lists">List</a> specified in request body. Body object must contain card `id`, and `listId`. If body object has `shouldPrepend: true`, the card will be added to the top of the list     | `canEditSpace`
-`PATCH`   | <code class="cards">/card</code>                        | Update card from object in request body. Body object must contain `id`. `spaceId` cannot be patched                                                                          | `canEditSpace`
-`PATCH`   | <code class="cards">/card/multiple</code>               | Updates multiple cards from an array of objects in request body. Works just like `PATCH /card`                                                                               | `canEditSpace`
-`PATCH`   | <code class="cards">/card/update-counter</code>         | Increment or decrement a card counter for voting. Body object must contain `cardId`, and either `shouldIncrement: true` or `shouldDecrement: true`              | None
-`PATCH`   | <code class="cards">/card/restore</code>                | Restore removed card specified in body                                                                                                                                              | `canEditSpace`
-`DELETE`  | <code class="cards">/card/list</code>                   | Remove card from the <a href="#lists" class="badge button-badge lists">List</a> that it's in. Body object must contain card `id`. The card's position will be shifted to the right of the list.                                       | `canEditSpace`
-`DELETE`  | <code class="cards">/card</code>                        | Remove card specified in body                                                                                                                                                       | `canEditSpace`
-`DELETE`  | <code class="cards">/card/permanent</code>              | Permanently remove card specified in body                                                                                                                                           | `canEditSpace`
+Method | Path | Description | Auth | App Key
+--- | --- | --- | --- | ---
+`GET`     | <code class="cards">/card/:cardId</code>                | Get info on a card                                                                                                                                                                  | `canViewSpace` | `read`
+`GET`     | <code class="cards">/card/multiple?cardIds=id1,id2</code> | Get info on multiple cards, up to 60 cardIds at a time                                                                                                                    | `canViewSpace` | `read`
+`GET`     | <code class="cards">/card/by-tag-name/:tagName</code>   | Get all cards with tag matching tagName in your <a href="#spaces" class="badge button-badge spaces">Spaces</a>                                                                                   | `apiKey` | `read`
+`GET`     | <code class="cards">/card/by-link-to-space/:spaceId</code>   | Get the cards and <a href="#spaces" class="badge button-badge spaces">Spaces</a> where `linkToSpaceId` is `spaceId`. Will only return spaces that the user can view                         | `apiKey and canViewSpace` | `read`
+`POST`    | <code class="cards">/card/search</code>                 | Get all cards that match a query. Body object must contain `query`. Only matches cards created by the user. Does not return removed cards, or cards from removed spaces. Searches are not case-insensitive                                       | `apiKey` | `read`
+`POST`    | <code class="cards">/card</code>                        | Create card from object in request body. Body object must contain `spaceId` and `name`. If not included, `x`, `y`, `z` will be positioned near the top left of the space, in a cascade pattern to prevent overlaps | `canEditSpace` | `edit`
+`POST`    | <code class="cards">/card/to-inbox</code>               | Create card saved to the user's `Inbox` space from object in request body and . Body object must contain `name`. Will return `404` if the user does not already have an `Inbox` space. Positioning works just like `POST /card`        | `canEditSpace` | `edit`
+`POST`    | <code class="cards">/card/multiple</code>               | Creates multiple cards from an array of objects in request body. Works just like `POST /card`                                                                                | `canEditSpace` | `edit`
+`PATCH`    | <code class="cards">/card/list</code>                   | Add card to a <a href="#lists" class="badge button-badge lists">List</a> specified in request body. Body object must contain card `id`, and `listId`. If body object has `shouldPrepend: true`, the card will be added to the top of the list     | `canEditSpace` | `edit`
+`PATCH`   | <code class="cards">/card</code>                        | Update card from object in request body. Body object must contain `id`. `spaceId` cannot be patched                                                                          | `canEditSpace` | `edit`
+`PATCH`   | <code class="cards">/card/multiple</code>               | Updates multiple cards from an array of objects in request body. Works just like `PATCH /card`                                                                               | `canEditSpace` | `edit`
+`PATCH`   | <code class="cards">/card/update-counter</code>         | Increment or decrement a card counter for voting. Body object must contain `cardId`, and either `shouldIncrement: true` or `shouldDecrement: true`              | None | `edit`
+`PATCH`   | <code class="cards">/card/restore</code>                | Restore removed card specified in body                                                                                                                                              | `canEditSpace` | `edit`
+`DELETE`  | <code class="cards">/card/list</code>                   | Remove card from the <a href="#lists" class="badge button-badge lists">List</a> that it's in. Body object must contain card `id`. The card's position will be shifted to the right of the list.                                       | `canEditSpace` | `edit`
+`DELETE`  | <code class="cards">/card</code>                        | Remove card specified in body                                                                                                                                                       | `canEditSpace` | `delete`
+`DELETE`  | <code class="cards">/card/permanent</code>              | Permanently remove card specified in body                                                                                                                                           | `canEditSpace` | `delete`
 
 </div>
 
@@ -332,12 +335,12 @@ Routes with Auth `canEditSpace` requires that your Authorization apiKey belongs 
 
 <div class="table-wrap connections routes-table-wrap">
 
-Method | Path | Description | Auth
---- | --- | --- | ---
-`GET`     | <code class="connections">/connection/<br/>:connectionId</code> | Get info on a connection                                                                                    | None
-`POST`    | <code class="connections">/connection</code>                    | Create connection(s) from object in request body. Object must contain `spaceId` and `color`                 | `canEditSpace`
-`PATCH`   | <code class="connections">/connection</code>                    | Update connection(s) from object in request body. `spaceId` cannot be patched.                              | `canEditSpace`
-`DELETE`  | <code class="connections">/connection</code>                    | Permenently remove connection(s) speced in req body                                                         | `canEditSpace`
+Method | Path | Description | Auth | App Key
+--- | --- | --- | --- | ---
+`GET`     | <code class="connections">/connection/<br/>:connectionId</code> | Get info on a connection                                                                                    | `canViewSpace` | `read`
+`POST`    | <code class="connections">/connection</code>                    | Create connection(s) from object in request body. Object must contain `spaceId` and `color`                 | `canEditSpace` | `edit`
+`PATCH`   | <code class="connections">/connection</code>                    | Update connection(s) from object in request body. `spaceId` cannot be patched.                              | `canEditSpace` | `edit`
+`DELETE`  | <code class="connections">/connection</code>                    | Permenently remove connection(s) speced in req body                                                         | `canEditSpace` | `delete`
 
 </div>
 
@@ -381,12 +384,12 @@ Routes with Auth `canEditSpace` requires that your Authorization apiKey belongs 
 
 <div class="table-wrap boxes routes-table-wrap">
 
-Method | Path | Description | Auth
---- | --- | --- | ---
-`GET`     | <code class="boxes">/box/:boxId</code>  | Get info on a box                                                         | `canViewSpace`
-`POST`    | <code class="boxes">/box</code>         | Create a box from object in request body. Object must contain `spaceId`   | `canEditSpace`
-`PATCH`   | <code class="boxes">/box</code>         | Update box from object in request body                                    | `canEditSpace`
-`DELETE`  | <code class="boxes">/box</code>         | Permenently remove box, from object in request body                       | `canEditSpace`
+Method | Path | Description | Auth | App Key
+--- | --- | --- | --- | ---
+`GET`     | <code class="boxes">/box/:boxId</code>  | Get info on a box                                                         | `canViewSpace` | `read`
+`POST`    | <code class="boxes">/box</code>         | Create a box from object in request body. Object must contain `spaceId`   | `canEditSpace` | `edit`
+`PATCH`   | <code class="boxes">/box</code>         | Update box from object in request body                                    | `canEditSpace` | `edit`
+`DELETE`  | <code class="boxes">/box</code>         | Permenently remove box, from object in request body                       | `canEditSpace` | `delete`
 
 </div>
 
@@ -435,12 +438,11 @@ Routes with Auth `canEditSpace` requires that your Authorization apiKey belongs 
 
 <div class="table-wrap lists routes-table-wrap">
 
-Method | Path | Description | Auth
---- | --- | --- | ---
-`GET`     | <code class="lists">/list/:listId</code>    | Get info on a list, including cards                                                             | `canViewSpace`
-`POST`    | <code class="lists">/list</code>            | Create a list from object in request body. Body object must contain `spaceId`                   | `canEditSpace`
-`PATCH`   | <code class="lists">/list</code>            | Update list from object in request body. Body object must contain `id` and `spaceId`            | `canEditSpace`
-`DELETE`  | <code class="lists">/list/</code>           | Permenently remove list in request body. Body object must contain `id` and `spaceId`            | `canEditSpace`
+Method | Path | Description | Auth | App Key
+--- | --- | --- | --- | ---
+`GET`     | <code class="lists">/list/:listId</code>    | Get info on a list, including cards                                                             | `canViewSpace` | `read`
+`POST`    | <code class="lists">/list</code>            | Create a list from object in request body. Body object must contain `spaceId`                   | `canEditSpace` | `edit`
+`PATCH`   | <code class="lists">/list</code>            | Update list from object in request body. Body object must contain `id` and `spaceId`            | `canEditSpace` | `edit`
 
 </div>
 
@@ -482,11 +484,11 @@ Routes with Auth `canEditSpace` requires that your Authorization apiKey belongs 
 
 <div class="table-wrap tags routes-table-wrap">
 
-Method | Path | Description | Auth
---- | --- | --- | ---
-`GET`     | <code class="tags">/tags/:tagName</code>          | Get all tags with tagName in your <a href="#spaces" class="badge button-badge spaces">Spaces</a>                                                                      | `apiKey`
-`GET`     | <code class="tags">/tags/by-card/:cardId</code>   | Get all tags in a <a href="#cards" class="badge button-badge cards">Cards</a>                                                                                        | `apiKey`
-`PATCH`   | <code class="tags">/tags/color</code>             | Change the color of all tags with the name specified in request body. Object must contain `name`, `color`     | `apiKey`
+Method | Path | Description | Auth | App Key
+--- | --- | --- | --- | ---
+`GET`     | <code class="tags">/tag/:tagName</code>          | Get all tags with tagName in your <a href="#spaces" class="badge button-badge spaces">Spaces</a>                                                                      | `apiKey` | `read`
+`GET`     | <code class="tags">/tag/by-card/:cardId</code>   | Get all tags in a <a href="#cards" class="badge button-badge cards">Cards</a>                                                                                        | `apiKey` | `read`
+`PATCH`   | <code class="tags">/tag/color</code>             | Change the color of all tags with the name specified in request body. Object must contain `name`, `color`     | `apiKey` | `edit`
 
 </div>
 
@@ -522,9 +524,9 @@ Routes with Auth as `apiKey` mean that the Authorization header apiKey must matc
 
 <div class="table-wrap notifications routes-table-wrap">
 
-Method | Path | Description | Auth
---- | --- | --- | ---
-`GET`   | <code class="notifications">/notifications</code>  | Get the last 50 notifications for the current user | `apiKey`
+Method | Path | Description | Auth | App Key
+--- | --- | --- | --- | ---
+`GET`   | <code class="notifications">/notification</code>  | Get the last 50 notifications for the current user | `apiKey` | `read`
 
 </div>
 
@@ -562,14 +564,14 @@ Other routes used by the kinopio-client app, which you can also use in your inte
 
 <div class="table-wrap other routes-table-wrap">
 
-Method | Path | Description | Auth
---- | --- | --- | ---
-`GET`   | <code class="other">/affiliate</code>  | returns affiliate info, promo url, commissions earned, and pending payout | `AffiliateUser`
-`GET`   | <code class="other">/services/community-backgrounds</code>  | Lists the space background images aded to the <a href="https://www.are.na/kinopio/community-backgrounds">are.na channel</a> | None
-`GET`   | <code class="other">/meta/date</code>  | Current time/timezone of kinopio-server | None
-`GET`   | <code class="other">/meta/changelog</code>  | Lists recent Kinopio new feature updates | None
-`GET`   | <code class="other">/meta/emojis</code>  | List of [unicode emojis](https://github.com/muan/unicode-emoji-json/blob/main/data-by-group.json) for the emoji picker | None
-`GET`   | <code class="other">/meta/random-name</code>  | returns a random word space name – based on the logic formerly used to generate space names | None
+Method | Path | Description | Auth | App Key
+--- | --- | --- | --- | ---
+`GET`   | <code class="other">/affiliate</code>  | returns affiliate info, promo url, commissions earned, and pending payout | `AffiliateUser` | `read`
+`GET`   | <code class="other">/services/community-backgrounds</code>  | Lists the space background images aded to the <a href="https://www.are.na/kinopio/community-backgrounds">are.na channel</a> | None | —
+`GET`   | <code class="other">/meta/date</code>  | Current time/timezone of kinopio-server | None | —
+`GET`   | <code class="other">/meta/changelog</code>  | Lists recent Kinopio new feature updates | None | —
+`GET`   | <code class="other">/meta/emojis</code>  | List of [unicode emojis](https://github.com/muan/unicode-emoji-json/blob/main/data-by-group.json) for the emoji picker | None | —
+`GET`   | <code class="other">/meta/random-name</code>  | returns a random word space name – based on the logic formerly used to generate space names | None | —
 
 </div>
 </section>

--- a/src/data/apiDocs.md
+++ b/src/data/apiDocs.md
@@ -1,5 +1,15 @@
 The Kinopio API is used to find, save, and update the spaces of signed up users. You can use it to make your own integrations and tools.
 
+<div class="table-wrap all">
+
+Base Path for All Routes | Description
+--- | --- 
+<code class="all">`https://api.kinopio.club`</code> | Confirm that the API server is online
+
+</div>
+
+-----
+
 ## Authentication
 
 You can auth requests with either your user or an app api key, both can be found in `User → Settings → Account → API`.
@@ -12,34 +22,19 @@ App API Key | `App-Authorization` | Scope is either `user`, `read`, `edit`, or `
 App API Key Scopes | Description
 --- | ---
 `user` | Can only read <a href="#users" class="badge button-badge users">User</a>profile data
-`read` | Can read content (user, spaces, cards, etc.)
+`read` | Can read content (<a href="#users" class="badge button-badge users">User</a>, <a href="#spaces" class="badge button-badge spaces">Spaces</a>, <a href="#cards" class="badge button-badge cards">Cards</a>, etc.)
 `edit` | Can read and edit content
 `delete` | Can read, edit, and delete content
 
 <p class="badge danger"><img class="icon key" src="@/assets/key.svg"/> API Keys are secrets, so be sure to keep them safe. For safety, prefer keys with the narrowest scope possible.</p>
 
+-----
+
 ## Rate Limits
 
 The API is limited to 5 requests per second. If you exceed this rate, you will receive a `429` response and will need to wait 30 seconds before subsequent requests will succeed.
 
--------
-
-## Routes and Attributes by Item Type
-
-<section class="section-wrap all">
-<h2 class="badge all">All</h2>
-<a class="anchor" name="all"></a>
-
-<div class="table-wrap all">
-
-Base Path for All Routes | Description | Scope
---- | --- | ---
-<code class="all">`https://api.kinopio.club`</code> | Confirm that the API server is online | —
-
-</div>
-</section>
-
-------
+-----
 
 <section class="section-wrap users">
 <a class="anchor" data-section="👯‍♀️" name="users"></a>

--- a/src/data/apiDocs.md
+++ b/src/data/apiDocs.md
@@ -4,7 +4,7 @@ The Kinopio API is used to find, save, and update the spaces of signed up users.
 
 You can auth requests with either your user or an app api key, both can be found in `User → Settings → Account → API`.
 
-Type | Header | Permissions | Description
+API Key Type | Header | Permissions | Description
 --- | --- | --- | ---
 User API Key | `Authorization` | Root, be careful | For personal projects only
 App API Key | `App-Authorization` | Scope is either `user`, `read`, `edit`, or `delete` | For integrations, apps, and projects meant to be used by others
@@ -12,7 +12,7 @@ App API Key | `App-Authorization` | Scope is either `user`, `read`, `edit`, or `
 App API Key Scopes | Description
 --- | ---
 `user` | Can only read <a href="#users" class="badge button-badge users">User</a>profile data
-`read` | Can read content (spaces, cards, etc.)
+`read` | Can read content (user, spaces, cards, etc.)
 `edit` | Can read and edit content
 `delete` | Can read, edit, and delete content
 
@@ -30,13 +30,11 @@ The API is limited to 5 requests per second. If you exceed this rate, you will r
 <h2 class="badge all">All</h2>
 <a class="anchor" name="all"></a>
 
-<span class="badge all">[https://api.kinopio.club](https://api.kinopio.club)</span>is the base path for all routes.
-
 <div class="table-wrap all">
 
-Method | Name | Description | Auth
---- | --- | --- | ---
-`GET` | <code class="all">/</code> | Confirm that the API server is online | None
+Base Path for All Routes | Description | Scope
+--- | --- | ---
+<code class="all">`https://api.kinopio.club`</code> | Confirm that the API server is online | —
 
 </div>
 </section>
@@ -55,25 +53,25 @@ Routes with Auth as `apiKey` mean that the Authorization header apiKey must matc
 
 <div class="table-wrap users routes-table-wrap">
 
-Method | Path | Description | Auth | App Key
---- | --- | --- | --- | ---
-`GET`   | <code class="users">/user/public/:userId</code>         | Gets public info on a user                                                                                                                                | None | —
-`GET`   | <code class="users">/user/public/explore-spaces/:userId</code>   | The a list of spaces with `showInExplore: true` created by the user                                                          | None | —
-`GET`   | <code class="users">/user/hidden-spaces</code>          | Get hidden spaces for the authenticating user                                                         | `apiKey` | `read`
-`GET`   | <code class="users">/user/public/multiple?userIds=id1,id2</code>        | Gets public info for multiple userIds, up to 60 userIds at a time                                      | None | —
-`GET`   | <code class="users">/user</code>                        | Get all info on the authenticating user                                                                                                                   | `apiKey` | `user`
-`GET`   | <code class="users">/user/favorite-spaces</code>        | Get favorite spaces for the authenticating user. Favorited spaces which have unread updates will have `isEdited: true`                      | `apiKey` | `read`
-`GET`   | <code class="users">/user/favorite-users</code>         | Get favorite users for the authenticating user                                                          | `apiKey` | `read`
-`GET`   | <code class="users">/user/favorite-colors</code>        | Get favorite colors for the authenticating user                                                         | `apiKey` | `read`
-`GET`   | <code class="users">/user/spaces</code>                 | Get a list of the user's <a href="#spaces" class="badge button-badge spaces">Spaces</a>. Use `/user/group-spaces` for spaces created by other members of groups they belong to           | `apiKey` | `read`
-`GET`   | <code class="users">/user/groups</code>                 | Get a list of the user's groups. Their role in each group (`member` or `admin`) is inside the `groupUser` object                                    | `apiKey` | `read`
-`GET`   | <code class="users">/user/group-spaces</code>           | Get a list of the user's group <a href="#spaces" class="badge button-badge spaces">Spaces</a> created by other members of groups they belong to                                          | `apiKey` | `read`
-`GET`   | <code class="users">/user/template-spaces</code>        | Get a list of the user's template <a href="#spaces" class="badge button-badge spaces">Spaces</a>. These include template spaces you made or are a collaborator in                        | `apiKey` | `read`
-`GET`   | <code class="users">/user/removed-spaces</code>         | Get <a href="#spaces" class="badge button-badge spaces">Spaces</a> removed by the authenticating user                                                                  | `apiKey` | `read`
-`GET`   | <code class="users">/user/inbox-space</code>            | Get info on the user's `Inbox` space. whether a space is an inbox or not is based on name only, so it's possible to have multiple `Inbox` spaces, but only one the most recently updated Inbox will be returned | `apiKey` | `read`
-`GET`   | <code class="users">/user/tags</code>                   | Get a list of the last edited <a href="#tags" class="badge button-badge tags">Tags</a> in your spaces                                                                  | `apiKey` | `read`
-`GET`   | <code class="users">/user/todos</code>                  | Get todo cards and boxes (item names start with `[]`, `[ ]`, or `[x]`), grouped by space                                                                            | `apiKey` | `read`
-`PATCH` | <code class="users">/user</code>                        | Update the user based on an object body with updated user attributes. You can't patch `apiKey`, `password`, `emailIsVerified`, or `email`       | `apiKey` | `edit`
+Method | Path | Description | Scope
+--- | --- | --- | ---
+`GET`   | <code class="users">/user/public/:userId</code>         | Gets public info on a user                                                                                                                                | —
+`GET`   | <code class="users">/user/public/explore-spaces/:userId</code>   | The a list of spaces with `showInExplore: true` created by the user                                                          | —
+`GET`   | <code class="users">/user/hidden-spaces</code>          | Get hidden spaces for the authenticating user                                                         | `read`
+`GET`   | <code class="users">/user/public/multiple?userIds=id1,id2</code>        | Gets public info for multiple userIds, up to 60 userIds at a time                                      | —
+`GET`   | <code class="users">/user</code>                        | Get all info on the authenticating user                                                                                                                   | `user`
+`GET`   | <code class="users">/user/favorite-spaces</code>        | Get favorite spaces for the authenticating user. Favorited spaces which have unread updates will have `isEdited: true`                      | `read`
+`GET`   | <code class="users">/user/favorite-users</code>         | Get favorite users for the authenticating user                                                          | `read`
+`GET`   | <code class="users">/user/favorite-colors</code>        | Get favorite colors for the authenticating user                                                         | `read`
+`GET`   | <code class="users">/user/spaces</code>                 | Get a list of the user's <a href="#spaces" class="badge button-badge spaces">Spaces</a>. Use `/user/group-spaces` for spaces created by other members of groups they belong to           | `read`
+`GET`   | <code class="users">/user/groups</code>                 | Get a list of the user's groups. Their role in each group (`member` or `admin`) is inside the `groupUser` object                                    | `read`
+`GET`   | <code class="users">/user/group-spaces</code>           | Get a list of the user's group <a href="#spaces" class="badge button-badge spaces">Spaces</a> created by other members of groups they belong to                                          | `read`
+`GET`   | <code class="users">/user/template-spaces</code>        | Get a list of the user's template <a href="#spaces" class="badge button-badge spaces">Spaces</a>. These include template spaces you made or are a collaborator in                        | `read`
+`GET`   | <code class="users">/user/removed-spaces</code>         | Get <a href="#spaces" class="badge button-badge spaces">Spaces</a> removed by the authenticating user                                                                  | `read`
+`GET`   | <code class="users">/user/inbox-space</code>            | Get info on the user's `Inbox` space. whether a space is an inbox or not is based on name only, so it's possible to have multiple `Inbox` spaces, but only one the most recently updated Inbox will be returned | `read`
+`GET`   | <code class="users">/user/tags</code>                   | Get a list of the last edited <a href="#tags" class="badge button-badge tags">Tags</a> in your spaces                                                                  | `read`
+`GET`   | <code class="users">/user/todos</code>                  | Get todo cards and boxes (item names start with `[]`, `[ ]`, or `[x]`), grouped by space                                                                            | `read`
+`PATCH` | <code class="users">/user</code>                        | Update the user based on an object body with updated user attributes. You can't patch `apiKey`, `password`, `emailIsVerified`, or `email`       | `edit`
 
 </div>
 
@@ -163,29 +161,29 @@ The `closed` privacy state refers to `Public Read Only`.
 
 <div class="table-wrap spaces routes-table-wrap">
 
-Method | Path | Description | Auth | App Key
---- | --- | --- | --- | ---
-`GET`    | <code class="spaces">/space/:spaceId</code>              | Get info on a space by id. Use `?textOnly=true` for card names only                               | `canViewSpace` | `read`
-`GET`    | <code class="spaces">/space/:spaceId/public-meta</code>    | Get public space info on non-private spaces                                                     | None | —
-`GET`    | <code class="spaces">/space/:spaceId/favorites</code>    | Get a list of users who have favorited the spaceId                                                | None | `read`
-`GET`    | <code class="spaces">/space/:spaceId/feed.json</code>    | `RSS feed` for cards recently created or updated in a space. Use `?apiKey=` for private spaces    | `canViewSpace` | —
-`GET`    | <code class="spaces">/space/:spaceId/<br>removed-cards</code> | Get <a href="#cards" class="badge button-badge cards">Cards</a> removed in a space                         | `canEditSpace` | `read`
-`GET`    | <code class="spaces">/space/explore-spaces</code>            | Get a list of recently updated public spaces which have been added to Explore. Sorted by date `showInExploreUpdatedAt` | None | —
-`GET`    | <code class="spaces">/space/explore-spaces/feed.json</code>  | `RSS feed` for new spaces added to Explore                                                    | None | —
-`GET`    | <code class="spaces">/space/live-spaces</code>           | Get a list of currently being edited spaces which are open or closed                              | None | —
-`GET`    | <code class="spaces">/space/multiple?spaceIds=id1,id2</code> | Get info on multiple spaces, up to 60 spaceIds at a time                                      | `canViewSpace` | `read`
-`GET`    | <code class="spaces">/space/public/multiple?spaceIds=id1,id2</code>        | Gets public info for multiple public spaces, up to 60 spaceIds at a time. | None | —
-`GET`    | <code class="spaces">/space/inbox</code>         | Get the current user's inbox space                                                                        | `apiKey` | `read`
-`GET`    | <code class="spaces">/space/everyone-spaces</code>            | Get a list of recent public spaces sorted by date `createdAt`                               | None | —
-`GET`    | <code class="spaces">/space/everyone-spaces/feed.json</code>  | `RSS feed` for recent public spaces                                                         | None | —
-`GET`    | <code class="spaces">/space/date-image</code>        | Get the image url for today's date card image                                                         | None | —
-`POST`   | <code class="spaces">/space</code>                       | Create a new space(s) from object(s) in request body. The owner will be the apiKey user           | `apiKey` | `edit`
-`POST`   | <code class="spaces">/space/search-explore-spaces</code>   | Get all `showInExplore` spaces based on space name. Body object must contain `query`. Searches are not case-insensitive           | None | —
-`PATCH`  | <code class="spaces">/space</code>                       | Update space(s) from object(s) in request body                                                    | `canEditSpace` | `edit`
-`PATCH`  | <code class="spaces">/space/restore/:spaceId</code>               | Restore removed space(s)  from object(s) in request body                                          | `canEditSpace` | `edit`
-`DELETE` | <code class="spaces">/space</code>                       | Remove space(s) specified in request body                                                         | `canEditSpace` | `delete`
-`DELETE` | <code class="spaces">/space/permanent</code>             | Permanently remove space(s) specified in request body                                             | `canEditSpace` | `delete`
-`DELETE` | <code class="spaces">/space/collaborator</code>          | Removes collaborator user from space. Request Body Keys: `spaceId`, `userId`                      | `canEditSpace` | `edit`
+Method | Path | Description | Scope
+--- | --- | --- | ---
+`GET`    | <code class="spaces">/space/:spaceId</code>              | Get info on a space by id. Use `?textOnly=true` for card names only                               | `read`
+`GET`    | <code class="spaces">/space/:spaceId/public-meta</code>    | Get public space info on non-private spaces                                                     | —
+`GET`    | <code class="spaces">/space/:spaceId/favorites</code>    | Get a list of users who have favorited the spaceId                                                | `read`
+`GET`    | <code class="spaces">/space/:spaceId/feed.json</code>    | `RSS feed` for cards recently created or updated in a space. Use `?apiKey=` for private spaces    | —
+`GET`    | <code class="spaces">/space/:spaceId/<br>removed-cards</code> | Get <a href="#cards" class="badge button-badge cards">Cards</a> removed in a space                         | `read`
+`GET`    | <code class="spaces">/space/explore-spaces</code>            | Get a list of recently updated public spaces which have been added to Explore. Sorted by date `showInExploreUpdatedAt` | —
+`GET`    | <code class="spaces">/space/explore-spaces/feed.json</code>  | `RSS feed` for new spaces added to Explore                                                    | —
+`GET`    | <code class="spaces">/space/live-spaces</code>           | Get a list of currently being edited spaces which are open or closed                              | —
+`GET`    | <code class="spaces">/space/multiple?spaceIds=id1,id2</code> | Get info on multiple spaces, up to 60 spaceIds at a time                                      | `read`
+`GET`    | <code class="spaces">/space/public/multiple?spaceIds=id1,id2</code>        | Gets public info for multiple public spaces, up to 60 spaceIds at a time. | —
+`GET`    | <code class="spaces">/space/inbox</code>         | Get the current user's inbox space                                                                        | `read`
+`GET`    | <code class="spaces">/space/everyone-spaces</code>            | Get a list of recent public spaces sorted by date `createdAt`                               | —
+`GET`    | <code class="spaces">/space/everyone-spaces/feed.json</code>  | `RSS feed` for recent public spaces                                                         | —
+`GET`    | <code class="spaces">/space/date-image</code>        | Get the image url for today's date card image                                                         | —
+`POST`   | <code class="spaces">/space</code>                       | Create a new space(s) from object(s) in request body. The owner will be the apiKey user           | `edit`
+`POST`   | <code class="spaces">/space/search-explore-spaces</code>   | Get all `showInExplore` spaces based on space name. Body object must contain `query`. Searches are not case-insensitive           | —
+`PATCH`  | <code class="spaces">/space</code>                       | Update space(s) from object(s) in request body                                                    | `edit`
+`PATCH`  | <code class="spaces">/space/restore/:spaceId</code>               | Restore removed space(s)  from object(s) in request body                                          | `edit`
+`DELETE` | <code class="spaces">/space</code>                       | Remove space(s) specified in request body                                                         | `delete`
+`DELETE` | <code class="spaces">/space/permanent</code>             | Permanently remove space(s) specified in request body                                             | `delete`
+`DELETE` | <code class="spaces">/space/collaborator</code>          | Removes collaborator user from space. Request Body Keys: `spaceId`, `userId`                      | `edit`
 
 </div>
 
@@ -256,24 +254,24 @@ Routes with Auth `canEditSpace` requires that your Authorization apiKey belongs 
 
 <div class="table-wrap cards routes-table-wrap">
 
-Method | Path | Description | Auth | App Key
---- | --- | --- | --- | ---
-`GET`     | <code class="cards">/card/:cardId</code>                | Get info on a card                                                                                                                                                                  | `canViewSpace` | `read`
-`GET`     | <code class="cards">/card/multiple?cardIds=id1,id2</code> | Get info on multiple cards, up to 60 cardIds at a time                                                                                                                    | `canViewSpace` | `read`
-`GET`     | <code class="cards">/card/by-tag-name/:tagName</code>   | Get all cards with tag matching tagName in your <a href="#spaces" class="badge button-badge spaces">Spaces</a>                                                                                   | `apiKey` | `read`
-`GET`     | <code class="cards">/card/by-link-to-space/:spaceId</code>   | Get the cards and <a href="#spaces" class="badge button-badge spaces">Spaces</a> where `linkToSpaceId` is `spaceId`. Will only return spaces that the user can view                         | `apiKey and canViewSpace` | `read`
-`POST`    | <code class="cards">/card/search</code>                 | Get all cards that match a query. Body object must contain `query`. Only matches cards created by the user. Does not return removed cards, or cards from removed spaces. Searches are not case-insensitive                                       | `apiKey` | `read`
-`POST`    | <code class="cards">/card</code>                        | Create card from object in request body. Body object must contain `spaceId` and `name`. If not included, `x`, `y`, `z` will be positioned near the top left of the space, in a cascade pattern to prevent overlaps | `canEditSpace` | `edit`
-`POST`    | <code class="cards">/card/to-inbox</code>               | Create card saved to the user's `Inbox` space from object in request body and . Body object must contain `name`. Will return `404` if the user does not already have an `Inbox` space. Positioning works just like `POST /card`        | `canEditSpace` | `edit`
-`POST`    | <code class="cards">/card/multiple</code>               | Creates multiple cards from an array of objects in request body. Works just like `POST /card`                                                                                | `canEditSpace` | `edit`
-`PATCH`    | <code class="cards">/card/list</code>                   | Add card to a <a href="#lists" class="badge button-badge lists">List</a> specified in request body. Body object must contain card `id`, and `listId`. If body object has `shouldPrepend: true`, the card will be added to the top of the list     | `canEditSpace` | `edit`
-`PATCH`   | <code class="cards">/card</code>                        | Update card from object in request body. Body object must contain `id`. `spaceId` cannot be patched                                                                          | `canEditSpace` | `edit`
-`PATCH`   | <code class="cards">/card/multiple</code>               | Updates multiple cards from an array of objects in request body. Works just like `PATCH /card`                                                                               | `canEditSpace` | `edit`
-`PATCH`   | <code class="cards">/card/update-counter</code>         | Increment or decrement a card counter for voting. Body object must contain `cardId`, and either `shouldIncrement: true` or `shouldDecrement: true`              | None | `edit`
-`PATCH`   | <code class="cards">/card/restore</code>                | Restore removed card specified in body                                                                                                                                              | `canEditSpace` | `edit`
-`DELETE`  | <code class="cards">/card/list</code>                   | Remove card from the <a href="#lists" class="badge button-badge lists">List</a> that it's in. Body object must contain card `id`. The card's position will be shifted to the right of the list.                                       | `canEditSpace` | `edit`
-`DELETE`  | <code class="cards">/card</code>                        | Remove card specified in body                                                                                                                                                       | `canEditSpace` | `delete`
-`DELETE`  | <code class="cards">/card/permanent</code>              | Permanently remove card specified in body                                                                                                                                           | `canEditSpace` | `delete`
+Method | Path | Description | Scope
+--- | --- | --- | ---
+`GET`     | <code class="cards">/card/:cardId</code>                | Get info on a card                                                                                                                                                                  | `read`
+`GET`     | <code class="cards">/card/multiple?cardIds=id1,id2</code> | Get info on multiple cards, up to 60 cardIds at a time                                                                                                                    | `read`
+`GET`     | <code class="cards">/card/by-tag-name/:tagName</code>   | Get all cards with tag matching tagName in your <a href="#spaces" class="badge button-badge spaces">Spaces</a>                                                                                   | `read`
+`GET`     | <code class="cards">/card/by-link-to-space/:spaceId</code>   | Get the cards and <a href="#spaces" class="badge button-badge spaces">Spaces</a> where `linkToSpaceId` is `spaceId`. Will only return spaces that the user can view                         | `read`
+`POST`    | <code class="cards">/card/search</code>                 | Get all cards that match a query. Body object must contain `query`. Only matches cards created by the user. Does not return removed cards, or cards from removed spaces. Searches are not case-insensitive                                       | `read`
+`POST`    | <code class="cards">/card</code>                        | Create card from object in request body. Body object must contain `spaceId` and `name`. If not included, `x`, `y`, `z` will be positioned near the top left of the space, in a cascade pattern to prevent overlaps | `edit`
+`POST`    | <code class="cards">/card/to-inbox</code>               | Create card saved to the user's `Inbox` space from object in request body and . Body object must contain `name`. Will return `404` if the user does not already have an `Inbox` space. Positioning works just like `POST /card`        | `edit`
+`POST`    | <code class="cards">/card/multiple</code>               | Creates multiple cards from an array of objects in request body. Works just like `POST /card`                                                                                | `edit`
+`PATCH`    | <code class="cards">/card/list</code>                   | Add card to a <a href="#lists" class="badge button-badge lists">List</a> specified in request body. Body object must contain card `id`, and `listId`. If body object has `shouldPrepend: true`, the card will be added to the top of the list     | `edit`
+`PATCH`   | <code class="cards">/card</code>                        | Update card from object in request body. Body object must contain `id`. `spaceId` cannot be patched                                                                          | `edit`
+`PATCH`   | <code class="cards">/card/multiple</code>               | Updates multiple cards from an array of objects in request body. Works just like `PATCH /card`                                                                               | `edit`
+`PATCH`   | <code class="cards">/card/update-counter</code>         | Increment or decrement a card counter for voting. Body object must contain `cardId`, and either `shouldIncrement: true` or `shouldDecrement: true`              | `edit`
+`PATCH`   | <code class="cards">/card/restore</code>                | Restore removed card specified in body                                                                                                                                              | `edit`
+`DELETE`  | <code class="cards">/card/list</code>                   | Remove card from the <a href="#lists" class="badge button-badge lists">List</a> that it's in. Body object must contain card `id`. The card's position will be shifted to the right of the list.                                       | `edit`
+`DELETE`  | <code class="cards">/card</code>                        | Remove card specified in body                                                                                                                                                       | `delete`
+`DELETE`  | <code class="cards">/card/permanent</code>              | Permanently remove card specified in body                                                                                                                                           | `delete`
 
 </div>
 
@@ -345,12 +343,12 @@ Routes with Auth `canEditSpace` requires that your Authorization apiKey belongs 
 
 <div class="table-wrap connections routes-table-wrap">
 
-Method | Path | Description | Auth | App Key
---- | --- | --- | --- | ---
-`GET`     | <code class="connections">/connection/<br/>:connectionId</code> | Get info on a connection                                                                                    | `canViewSpace` | `read`
-`POST`    | <code class="connections">/connection</code>                    | Create connection(s) from object in request body. Object must contain `spaceId` and `color`                 | `canEditSpace` | `edit`
-`PATCH`   | <code class="connections">/connection</code>                    | Update connection(s) from object in request body. `spaceId` cannot be patched.                              | `canEditSpace` | `edit`
-`DELETE`  | <code class="connections">/connection</code>                    | Permenently remove connection(s) speced in req body                                                         | `canEditSpace` | `delete`
+Method | Path | Description | Scope
+--- | --- | --- | ---
+`GET`     | <code class="connections">/connection/<br/>:connectionId</code> | Get info on a connection                                                                                    | `read`
+`POST`    | <code class="connections">/connection</code>                    | Create connection(s) from object in request body. Object must contain `spaceId` and `color`                 | `edit`
+`PATCH`   | <code class="connections">/connection</code>                    | Update connection(s) from object in request body. `spaceId` cannot be patched.                              | `edit`
+`DELETE`  | <code class="connections">/connection</code>                    | Permenently remove connection(s) speced in req body                                                         | `delete`
 
 </div>
 
@@ -394,12 +392,12 @@ Routes with Auth `canEditSpace` requires that your Authorization apiKey belongs 
 
 <div class="table-wrap boxes routes-table-wrap">
 
-Method | Path | Description | Auth | App Key
---- | --- | --- | --- | ---
-`GET`     | <code class="boxes">/box/:boxId</code>  | Get info on a box                                                         | `canViewSpace` | `read`
-`POST`    | <code class="boxes">/box</code>         | Create a box from object in request body. Object must contain `spaceId`   | `canEditSpace` | `edit`
-`PATCH`   | <code class="boxes">/box</code>         | Update box from object in request body                                    | `canEditSpace` | `edit`
-`DELETE`  | <code class="boxes">/box</code>         | Permenently remove box, from object in request body                       | `canEditSpace` | `delete`
+Method | Path | Description | Scope
+--- | --- | --- | ---
+`GET`     | <code class="boxes">/box/:boxId</code>  | Get info on a box                                                         | `read`
+`POST`    | <code class="boxes">/box</code>         | Create a box from object in request body. Object must contain `spaceId`   | `edit`
+`PATCH`   | <code class="boxes">/box</code>         | Update box from object in request body                                    | `edit`
+`DELETE`  | <code class="boxes">/box</code>         | Permenently remove box, from object in request body                       | `delete`
 
 </div>
 
@@ -448,11 +446,11 @@ Routes with Auth `canEditSpace` requires that your Authorization apiKey belongs 
 
 <div class="table-wrap lists routes-table-wrap">
 
-Method | Path | Description | Auth | App Key
---- | --- | --- | --- | ---
-`GET`     | <code class="lists">/list/:listId</code>    | Get info on a list, including cards                                                             | `canViewSpace` | `read`
-`POST`    | <code class="lists">/list</code>            | Create a list from object in request body. Body object must contain `spaceId`                   | `canEditSpace` | `edit`
-`PATCH`   | <code class="lists">/list</code>            | Update list from object in request body. Body object must contain `id` and `spaceId`            | `canEditSpace` | `edit`
+Method | Path | Description | Scope
+--- | --- | --- | ---
+`GET`     | <code class="lists">/list/:listId</code>    | Get info on a list, including cards                                                             | `read`
+`POST`    | <code class="lists">/list</code>            | Create a list from object in request body. Body object must contain `spaceId`                   | `edit`
+`PATCH`   | <code class="lists">/list</code>            | Update list from object in request body. Body object must contain `id` and `spaceId`            | `edit`
 
 </div>
 
@@ -494,11 +492,11 @@ Routes with Auth `canEditSpace` requires that your Authorization apiKey belongs 
 
 <div class="table-wrap tags routes-table-wrap">
 
-Method | Path | Description | Auth | App Key
---- | --- | --- | --- | ---
-`GET`     | <code class="tags">/tag/:tagName</code>          | Get all tags with tagName in your <a href="#spaces" class="badge button-badge spaces">Spaces</a>                                                                      | `apiKey` | `read`
-`GET`     | <code class="tags">/tag/by-card/:cardId</code>   | Get all tags in a <a href="#cards" class="badge button-badge cards">Cards</a>                                                                                        | `apiKey` | `read`
-`PATCH`   | <code class="tags">/tag/color</code>             | Change the color of all tags with the name specified in request body. Object must contain `name`, `color`     | `apiKey` | `edit`
+Method | Path | Description | Scope
+--- | --- | --- | ---
+`GET`     | <code class="tags">/tag/:tagName</code>          | Get all tags with tagName in your <a href="#spaces" class="badge button-badge spaces">Spaces</a>                                                                      | `read`
+`GET`     | <code class="tags">/tag/by-card/:cardId</code>   | Get all tags in a <a href="#cards" class="badge button-badge cards">Cards</a>                                                                                        | `read`
+`PATCH`   | <code class="tags">/tag/color</code>             | Change the color of all tags with the name specified in request body. Object must contain `name`, `color`     | `edit`
 
 </div>
 
@@ -534,9 +532,9 @@ Routes with Auth as `apiKey` mean that the Authorization header apiKey must matc
 
 <div class="table-wrap notifications routes-table-wrap">
 
-Method | Path | Description | Auth | App Key
---- | --- | --- | --- | ---
-`GET`   | <code class="notifications">/notification</code>  | Get the last 50 notifications for the current user | `apiKey` | `read`
+Method | Path | Description | Scope
+--- | --- | --- | ---
+`GET`   | <code class="notifications">/notification</code>  | Get the last 50 notifications for the current user | `read`
 
 </div>
 
@@ -575,14 +573,14 @@ Other routes used by the kinopio-client app, which you can also use in your inte
 
 <div class="table-wrap other routes-table-wrap">
 
-Method | Path | Description | Auth | App Key
---- | --- | --- | --- | ---
-`GET`   | <code class="other">/affiliate</code>  | returns affiliate info, promo url, commissions earned, and pending payout | `AffiliateUser` | `read`
-`GET`   | <code class="other">/services/community-backgrounds</code>  | Lists the space background images aded to the <a href="https://www.are.na/kinopio/community-backgrounds">are.na channel</a> | None | —
-`GET`   | <code class="other">/meta/date</code>  | Current time/timezone of kinopio-server | None | —
-`GET`   | <code class="other">/meta/changelog</code>  | Lists recent Kinopio new feature updates | None | —
-`GET`   | <code class="other">/meta/emojis</code>  | List of [unicode emojis](https://github.com/muan/unicode-emoji-json/blob/main/data-by-group.json) for the emoji picker | None | —
-`GET`   | <code class="other">/meta/random-name</code>  | returns a random word space name – based on the logic formerly used to generate space names | None | —
+Method | Path | Description | Scope
+--- | --- | --- | ---
+`GET`   | <code class="other">/affiliate</code>  | returns affiliate info, promo url, commissions earned, and pending payout | `read`
+`GET`   | <code class="other">/services/community-backgrounds</code>  | Lists the space background images aded to the <a href="https://www.are.na/kinopio/community-backgrounds">are.na channel</a> | —
+`GET`   | <code class="other">/meta/date</code>  | Current time/timezone of kinopio-server | —
+`GET`   | <code class="other">/meta/changelog</code>  | Lists recent Kinopio new feature updates | —
+`GET`   | <code class="other">/meta/emojis</code>  | List of [unicode emojis](https://github.com/muan/unicode-emoji-json/blob/main/data-by-group.json) for the emoji picker | —
+`GET`   | <code class="other">/meta/random-name</code>  | returns a random word space name – based on the logic formerly used to generate space names | —
 
 </div>
 </section>

--- a/src/data/apiKeyScopes.js
+++ b/src/data/apiKeyScopes.js
@@ -3,7 +3,7 @@
 const scopes = [
   {
     name: 'user',
-    friendlyName: 'Read User',
+    friendlyName: 'User',
     description: 'Can only read your user profile.'
   },
   {

--- a/src/data/apiKeyScopes.js
+++ b/src/data/apiKeyScopes.js
@@ -1,34 +1,26 @@
 // app api key scopes
 
 const scopes = [
-  // {
-  //   name: 'user',
-  //   friendlyName: 'Open to Comments',
-  //   description: 'Anyone with the URL can view and add comments. Only collaborators can edit.',
-  //   color: 'success',
-  //   icon: 'comment'
-  // },
-  // {
-  //   name: 'read',
-  //   friendlyName: 'Open to Comments',
-  //   description: 'Anyone with the URL can view and add comments. Only collaborators can edit.',
-  //   color: 'success',
-  //   icon: 'comment'
-  // },
-  // {
-  //   name: 'edit',
-  //   friendlyName: 'Open to Comments',
-  //   description: 'Anyone with the URL can view and add comments. Only collaborators can edit.',
-  //   color: 'success',
-  //   icon: 'comment'
-  // },
-  // {
-  //   name: 'delete',
-  //   friendlyName: 'Open to Comments',
-  //   description: 'Anyone with the URL can view and add comments. Only collaborators can edit.',
-  //   color: 'success',
-  //   icon: 'comment'
-  // }
+  {
+    name: 'user',
+    friendlyName: 'Read User',
+    description: 'Can only read your user profile.'
+  },
+  {
+    name: 'read',
+    friendlyName: 'Read',
+    description: 'Can read all your content (user, spaces, cards, etc).'
+  },
+  {
+    name: 'edit',
+    friendlyName: 'Edit',
+    description: 'Can read and edit your content.'
+  },
+  {
+    name: 'delete',
+    friendlyName: 'Delete',
+    description: 'Can fully read, edit, and delete your content.'
+  }
 ]
 
 export default scopes

--- a/src/data/apiKeyScopes.js
+++ b/src/data/apiKeyScopes.js
@@ -1,0 +1,34 @@
+// app api key scopes
+
+const scopes = [
+  // {
+  //   name: 'user',
+  //   friendlyName: 'Open to Comments',
+  //   description: 'Anyone with the URL can view and add comments. Only collaborators can edit.',
+  //   color: 'success',
+  //   icon: 'comment'
+  // },
+  // {
+  //   name: 'read',
+  //   friendlyName: 'Open to Comments',
+  //   description: 'Anyone with the URL can view and add comments. Only collaborators can edit.',
+  //   color: 'success',
+  //   icon: 'comment'
+  // },
+  // {
+  //   name: 'edit',
+  //   friendlyName: 'Open to Comments',
+  //   description: 'Anyone with the URL can view and add comments. Only collaborators can edit.',
+  //   color: 'success',
+  //   icon: 'comment'
+  // },
+  // {
+  //   name: 'delete',
+  //   friendlyName: 'Open to Comments',
+  //   description: 'Anyone with the URL can view and add comments. Only collaborators can edit.',
+  //   color: 'success',
+  //   icon: 'comment'
+  // }
+]
+
+export default scopes

--- a/src/stores/useApiStore.js
+++ b/src/stores/useApiStore.js
@@ -1597,8 +1597,6 @@ export const useApiStore = defineStore('api', {
       }
     },
     async rotateAppApiKey (body) {
-      console.log('🍒🍒🍒 rotateAppApiKey', body)
-
       const globalStore = useGlobalStore()
       const userStore = useUserStore()
       const apiKey = userStore.apiKey
@@ -1613,20 +1611,18 @@ export const useApiStore = defineStore('api', {
       }
     },
     async deleteAppApiKey (body) {
-      console.log('🍒deleteAppApiKey', body)
-
-      // const globalStore = useGlobalStore()
-      // const userStore = useUserStore()
-      // const apiKey = userStore.apiKey
-      // const isOnline = globalStore.isOnline
-      // if (!shouldRequest({ apiKey, isOnline })) { return }
-      // try {
-      //   const options = await this.requestOptions({ body, method: 'DELETE' })
-      //   const response = await fetch(`${consts.apiHost()}/group/`, options)
-      //   return normalizeResponse(response)
-      // } catch (error) {
-      //   this.handleServerError({ name: 'deleteGroupPermanent', error })
-      // }
+      const globalStore = useGlobalStore()
+      const userStore = useUserStore()
+      const apiKey = userStore.apiKey
+      const isOnline = globalStore.isOnline
+      if (!shouldRequest({ apiKey, isOnline })) { return }
+      try {
+        const options = await this.requestOptions({ body, method: 'DELETE' })
+        const response = await fetch(`${consts.apiHost()}/app-api-key`, options)
+        return normalizeResponse(response)
+      } catch (error) {
+        this.handleServerError({ name: 'deleteGroupPermanent', error })
+      }
     }
 
   }

--- a/src/stores/useApiStore.js
+++ b/src/stores/useApiStore.js
@@ -1506,6 +1506,9 @@ export const useApiStore = defineStore('api', {
         this.handleServerError({ name: 'deleteGroupPermanent', error })
       }
     },
+
+    // Analytics
+
     async sendAnalyticsEvent (body) {
       try {
         const headers = new Headers({
@@ -1561,6 +1564,74 @@ export const useApiStore = defineStore('api', {
       } catch (error) {
         this.handleServerError({ name: 'getAffiliate', error })
       }
+    },
+
+    // App API Keys
+
+    // async getUserGroups () {
+    //   const globalStore = useGlobalStore()
+    //   const userStore = useUserStore()
+    //   const apiKey = userStore.apiKey
+    //   const isOnline = globalStore.isOnline
+    //   if (!shouldRequest({ apiKey, isOnline })) { return }
+    //   try {
+    //     globalStore.isLoadingGroups = true
+    //     const options = await this.requestOptions({ method: 'GET' })
+    //     const response = await fetch(`${consts.apiHost()}/user/groups`, options)
+    //     globalStore.isLoadingGroups = false
+    //     return normalizeResponse(response)
+    //   } catch (error) {
+    //     this.handleServerError({ name: 'getUserGroups', error })
+    //   }
+    //   globalStore.isLoadingGroups = false
+    // },
+
+    // async createGroup (body) {
+    //   const globalStore = useGlobalStore()
+    //   const userStore = useUserStore()
+    //   const apiKey = userStore.apiKey
+    //   const isOnline = globalStore.isOnline
+    //   if (!shouldRequest({ apiKey, isOnline })) { return }
+    //   try {
+    //     const options = await this.requestOptions({ body, method: 'POST' })
+    //     const response = await fetch(`${consts.apiHost()}/group/`, options)
+    //     return normalizeResponse(response)
+    //   } catch (error) {
+    //     this.handleServerError({ name: 'createGroup', error })
+    //   }
+    // },
+    async updateAppApiKey (body) {
+      console.log('🍒deleteAppApiKey', body)
+
+      // const globalStore = useGlobalStore()
+      // const userStore = useUserStore()
+      // const apiKey = userStore.apiKey
+      // const isOnline = globalStore.isOnline
+      // if (!shouldRequest({ apiKey, isOnline })) { return }
+      // try {
+      //   const options = await this.requestOptions({ body, method: 'PATCH' })
+      //   const response = await fetch(`${consts.apiHost()}/connection/multiple`, options)
+      //   return normalizeResponse(response)
+      // } catch (error) {
+      //   this.handleServerError({ name: 'updateConnections', error })
+      // }
+    },
+
+    async deleteAppApiKey (body) {
+      console.log('🍒deleteAppApiKey', body)
+
+      // const globalStore = useGlobalStore()
+      // const userStore = useUserStore()
+      // const apiKey = userStore.apiKey
+      // const isOnline = globalStore.isOnline
+      // if (!shouldRequest({ apiKey, isOnline })) { return }
+      // try {
+      //   const options = await this.requestOptions({ body, method: 'DELETE' })
+      //   const response = await fetch(`${consts.apiHost()}/group/`, options)
+      //   return normalizeResponse(response)
+      // } catch (error) {
+      //   this.handleServerError({ name: 'deleteGroupPermanent', error })
+      // }
     }
 
   }

--- a/src/stores/useApiStore.js
+++ b/src/stores/useApiStore.js
@@ -1568,40 +1568,36 @@ export const useApiStore = defineStore('api', {
 
     // App API Keys
 
-    // async getUserGroups () {
-    //   const globalStore = useGlobalStore()
-    //   const userStore = useUserStore()
-    //   const apiKey = userStore.apiKey
-    //   const isOnline = globalStore.isOnline
-    //   if (!shouldRequest({ apiKey, isOnline })) { return }
-    //   try {
-    //     globalStore.isLoadingGroups = true
-    //     const options = await this.requestOptions({ method: 'GET' })
-    //     const response = await fetch(`${consts.apiHost()}/user/groups`, options)
-    //     globalStore.isLoadingGroups = false
-    //     return normalizeResponse(response)
-    //   } catch (error) {
-    //     this.handleServerError({ name: 'getUserGroups', error })
-    //   }
-    //   globalStore.isLoadingGroups = false
-    // },
-
-    // async createGroup (body) {
-    //   const globalStore = useGlobalStore()
-    //   const userStore = useUserStore()
-    //   const apiKey = userStore.apiKey
-    //   const isOnline = globalStore.isOnline
-    //   if (!shouldRequest({ apiKey, isOnline })) { return }
-    //   try {
-    //     const options = await this.requestOptions({ body, method: 'POST' })
-    //     const response = await fetch(`${consts.apiHost()}/group/`, options)
-    //     return normalizeResponse(response)
-    //   } catch (error) {
-    //     this.handleServerError({ name: 'createGroup', error })
-    //   }
-    // },
+    async getAppApiKeys () {
+      const globalStore = useGlobalStore()
+      const userStore = useUserStore()
+      const apiKey = userStore.apiKey
+      const isOnline = globalStore.isOnline
+      if (!shouldRequest({ apiKey, isOnline })) { return }
+      try {
+        const options = await this.requestOptions({ method: 'GET' })
+        const response = await fetch(`${consts.apiHost()}/app-api-key`, options)
+        return normalizeResponse(response)
+      } catch (error) {
+        this.handleServerError({ name: 'getAppApiKeys', error })
+      }
+    },
+    async createAppApiKey (body) {
+      const globalStore = useGlobalStore()
+      const userStore = useUserStore()
+      const apiKey = userStore.apiKey
+      const isOnline = globalStore.isOnline
+      if (!shouldRequest({ apiKey, isOnline })) { return }
+      try {
+        const options = await this.requestOptions({ body, method: 'POST' })
+        const response = await fetch(`${consts.apiHost()}/app-api-key`, options)
+        return normalizeResponse(response)
+      } catch (error) {
+        this.handleServerError({ name: 'createAppApiKey', error })
+      }
+    },
     async updateAppApiKey (body) {
-      console.log('🍒deleteAppApiKey', body)
+      console.log('🍒 updateAppApiKey', body)
 
       // const globalStore = useGlobalStore()
       // const userStore = useUserStore()
@@ -1616,7 +1612,6 @@ export const useApiStore = defineStore('api', {
       //   this.handleServerError({ name: 'updateConnections', error })
       // }
     },
-
     async deleteAppApiKey (body) {
       console.log('🍒deleteAppApiKey', body)
 

--- a/src/stores/useApiStore.js
+++ b/src/stores/useApiStore.js
@@ -1596,21 +1596,21 @@ export const useApiStore = defineStore('api', {
         this.handleServerError({ name: 'createAppApiKey', error })
       }
     },
-    async updateAppApiKey (body) {
-      console.log('🍒 updateAppApiKey', body)
+    async rotateAppApiKey (body) {
+      console.log('🍒🍒🍒 rotateAppApiKey', body)
 
-      // const globalStore = useGlobalStore()
-      // const userStore = useUserStore()
-      // const apiKey = userStore.apiKey
-      // const isOnline = globalStore.isOnline
-      // if (!shouldRequest({ apiKey, isOnline })) { return }
-      // try {
-      //   const options = await this.requestOptions({ body, method: 'PATCH' })
-      //   const response = await fetch(`${consts.apiHost()}/connection/multiple`, options)
-      //   return normalizeResponse(response)
-      // } catch (error) {
-      //   this.handleServerError({ name: 'updateConnections', error })
-      // }
+      const globalStore = useGlobalStore()
+      const userStore = useUserStore()
+      const apiKey = userStore.apiKey
+      const isOnline = globalStore.isOnline
+      if (!shouldRequest({ apiKey, isOnline })) { return }
+      try {
+        const options = await this.requestOptions({ body, method: 'PATCH' })
+        const response = await fetch(`${consts.apiHost()}/app-api-key/rotate-key`, options)
+        return normalizeResponse(response)
+      } catch (error) {
+        this.handleServerError({ name: 'rotateAppApiKey', error })
+      }
     },
     async deleteAppApiKey (body) {
       console.log('🍒deleteAppApiKey', body)

--- a/src/views/Api.vue
+++ b/src/views/Api.vue
@@ -91,9 +91,6 @@ const updateSystemTheme = () => {
 const items = computed(() => {
   let items = [
     {
-      name: 'All',
-      color: 'khaki'
-    }, {
       name: 'Users',
       color: '#b9a8ff'
     }, {
@@ -155,6 +152,8 @@ AboutJsonLd
 </template>
 
 <style lang="stylus">
+:root
+  --api-badge-all khaki
 main.api-page-wrap
   .page-wrap
     max-width 900px
@@ -281,6 +280,8 @@ main.api-page-wrap
     border-style solid
     table-layout fixed
     width 100%
+    // th + th
+    //   border-left 1px solid var(--primary-border)
     th,
     td
       padding 8px

--- a/src/views/Api.vue
+++ b/src/views/Api.vue
@@ -292,6 +292,11 @@ main.api-page-wrap
       &:hover
         background var(--secondary-hover-background)
 
+  .table-wrap.all
+    code
+      > code
+        background transparent
+        padding 0
   // custom column widths
 
   .routes-table-wrap

--- a/src/views/Api.vue
+++ b/src/views/Api.vue
@@ -158,6 +158,9 @@ AboutJsonLd
 main.api-page-wrap
   .page-wrap
     max-width 900px
+  hr
+    margin-top 2rem
+    margin-bottom 1rem
   p
     max-width 440px // same as page.styl
   ul.api-toc


### PR DESCRIPTION
This documents the app API keys and their scopes based on https://github.com/kinopio-club/kinopio-server/pull/175.

I assume we should keep working on this and merge it once we have a UI in the client to CRUD app API keys.

In addition to the scope documentation this includes some fixes for documentation drift. Specifically:
- /tags -> /tag and /notifications -> /notification (singular mounts)
- everyones-spaces -> everyone-spaces, search-explore-space ->
  search-explore-spaces, removedCards -> removed-cards, restore ->
  restore/:spaceId
- POST /card/list -> PATCH /card/list
- GET /connection/:connectionId auth None -> canViewSpace
- fix malformed /space/public/multiple row, remove nonexistent
  DELETE /list

I decided to include them in this PR to prevent merge conflicts.