### PR TITLE
Don't move comment cards if filtered when moving containing box

### DIFF
--- a/src/stores/useCardStore.js
+++ b/src/stores/useCardStore.js
@@ -62,7 +62,6 @@ export const useCardStore = defineStore('cards', {
       cards = cards.filter(card => {
         if (card.isLocked) { return }
         if (card.isRemoved) { return }
-        if (userStore.filterComments && card.isComment) { return }
         return true
       })
       // sort by y

--- a/src/stores/useCardStore.js
+++ b/src/stores/useCardStore.js
@@ -55,8 +55,6 @@ export const useCardStore = defineStore('cards', {
       return cards
     },
     getCardsSelectableByY () {
-      const globalStore = useGlobalStore()
-      const userStore = useUserStore()
       let cards = this.getAllCards
       // filter
       cards = cards.filter(card => {

--- a/src/stores/useCardStore.js
+++ b/src/stores/useCardStore.js
@@ -56,12 +56,13 @@ export const useCardStore = defineStore('cards', {
     },
     getCardsSelectableByY () {
       const globalStore = useGlobalStore()
+      const userStore = useUserStore()
       let cards = this.getAllCards
       // filter
       cards = cards.filter(card => {
         if (card.isLocked) { return }
         if (card.isRemoved) { return }
-        if (globalStore.filterComments && card.isComment) { return }
+        if (userStore.filterComments && card.isComment) { return }
         return true
       })
       // sort by y


### PR DESCRIPTION
The code was previously attempting to use the non-existent property `filterComments` on the global store, which would always be a falsey value. Thus the right side of the `&&` would never be evaluated, and the filter operation would not remove the comment card.

I'm not sure if this is actually the desired behavior, since at some level it feels intuitive to me that a comment card in a box would be moved even if the user can't see it. But this is technically a bug fix due to no longer attempting to use a non-existent value and thus never being able to reach a specific branch in an `if`.