### PR TITLE
Change Card Attributes `maxWidth` from Boolean to Integer

### DIFF
--- a/src/data/apiDocs.md
+++ b/src/data/apiDocs.md
@@ -286,7 +286,7 @@ Name | Type | Description
 <code class="cards">linkToSpaceId</code>              | `String`  | The `spaceId` linked to in the card name
 <code class="cards">linkToCardId</code>               | `String`  | The `cardId` linked to in the card name. A card link will always also include `linkToSpaceId` (but not vice versa)
 <code class="cards">linkToSpaceCollaboratorKey</code> | `String`  | The `collaboratorKey` used to invite someone to the space specified in `linkToSpaceId`. Indicates the the space has a space invite link
-<code class="cards">maxWidth</code>         | `Boolean` | Sets the default maximum width before cards text starts wrapping
+<code class="cards">maxWidth</code>         | `Integer` | Sets the default maximum width before cards text starts wrapping
 <code class="cards">name</code>                       | `String`  | The name of the card is its main text. Limited to 4000 characters
 <code class="cards">nameUpdatedAt</code>            | `String`  | The date when the card name was last updated
 <code class="cards">nameUpdatedByUserId</code>      | `String`  | The user id that last updated the name of the card


### PR DESCRIPTION
As far as I can tell from the code, the `maxWidth` property for cards is a number. (e.g.: the usage of it in `src/data/hello.json` which looks like the template for a user's first space) But the API docs say that it's a boolean. This seems like it's an oversight and doesn't match up with what the API actually expects.

If boolean truly is what it expects, this change can be easily ignored. And maybe the comment can be updated to indicate what is done with the boolean value if so.