### PR TITLE
reduce card intersection observer margin when zoomed out

### DIFF
--- a/src/components/Box.vue
+++ b/src/components/Box.vue
@@ -53,6 +53,8 @@ onMounted(() => {
     ({ name, args }) => {
       if (name === 'updateRemoteCurrentConnection' || name === 'removeRemoteCurrentConnection') {
         updateRemoteConnections()
+      } else if (name === 'triggerUpdateViewportObservers') {
+        initViewportObserver()
       }
     }
   )
@@ -156,16 +158,16 @@ const initViewportObserver = async () => {
     }
     const target = boxElement.value
     if (!target) { return }
-    observer = new IntersectionObserver(callback, { rootMargin: '50%' })
+    observer = new IntersectionObserver(callback, { rootMargin: globalStore.getViewportObserverRootMargin })
     observer.observe(target)
   } catch (error) {
     console.error('🚒 boxElement initViewportObserver', error)
   }
 }
 const removeViewportObserver = () => {
-  const target = boxElement.value
   if (!observer) { return }
-  observer.unobserve(target)
+  observer.disconnect()
+  observer = null
 }
 
 // styles

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -113,6 +113,8 @@ onMounted(async () => {
         cancelLocking()
       } else if (name === 'triggerIsSnappingToList') {
         state.isSnappingToList = true
+      } else if (name === 'triggerUpdateViewportObservers') {
+        initViewportObserver()
       }
     }
   )
@@ -1599,6 +1601,7 @@ const userDetailsIsUser = computed(() => {
 // is visible in viewport, perf, should render
 
 const initViewportObserver = async () => {
+  removeViewportObserver()
   await nextTick()
   try {
     const callback = (entries, observer) => {
@@ -1612,16 +1615,16 @@ const initViewportObserver = async () => {
       })
     }
     const target = cardElement.value
-    observer = new IntersectionObserver(callback, { rootMargin: '50%' })
+    observer = new IntersectionObserver(callback, { rootMargin: globalStore.getViewportObserverRootMargin })
     observer.observe(target)
   } catch (error) {
     console.error('🚒 card initViewportObserver', error)
   }
 }
 const removeViewportObserver = () => {
-  const target = cardElement.value
   if (!observer) { return }
-  observer.unobserve(target)
+  observer.disconnect()
+  observer = null
 }
 const shouldRender = computed(() => {
   const shouldExplitlyRender = globalStore.shouldExplicitlyRenderCardIds[props.card.id]

--- a/src/components/Connection.vue
+++ b/src/components/Connection.vue
@@ -45,6 +45,8 @@ onMounted(() => {
         showConnectionDetails(event, isFromStore)
       } else if (name === 'closeAllDialogs') {
         updatePathWhileDragging(null)
+      } else if (name === 'triggerUpdateViewportObservers') {
+        initViewportObserver()
       }
     }
   )
@@ -466,6 +468,7 @@ const checkIsMultiTouch = (event) => {
 
 const initViewportObserver = async () => {
   if (globalStore.disableViewportOptimizations) { return }
+  removeViewportObserver()
   await nextTick()
   try {
     const callback = (entries, observer) => {
@@ -479,16 +482,16 @@ const initViewportObserver = async () => {
     }
     const target = observerTarget.value
     if (!target) { return }
-    observer = new IntersectionObserver(callback, { rootMargin: '50%' })
+    observer = new IntersectionObserver(callback, { rootMargin: globalStore.getViewportObserverRootMargin })
     observer.observe(target)
   } catch (error) {
     console.error('🚒 connection initViewportObserver', error)
   }
 }
 const removeViewportObserver = () => {
-  const target = observerTarget.value
   if (!observer) { return }
-  observer.unobserve(target)
+  observer.disconnect()
+  observer = null
 }
 </script>
 

--- a/src/components/List.vue
+++ b/src/components/List.vue
@@ -47,6 +47,8 @@ onMounted(() => {
     ({ name, args }) => {
       if (name === 'clearDraggingItems') {
         state.isDraggingCardOverList = false
+      } else if (name === 'triggerUpdateViewportObservers') {
+        initViewportObserver()
       }
     }
   )
@@ -94,16 +96,16 @@ const initViewportObserver = async () => {
     }
     const target = listElement.value
     if (!target) { return }
-    observer = new IntersectionObserver(callback, { rootMargin: '50%' })
+    observer = new IntersectionObserver(callback, { rootMargin: globalStore.getViewportObserverRootMargin })
     observer.observe(target)
   } catch (error) {
     console.error('🚒 listElement initViewportObserver', error)
   }
 }
 const removeViewportObserver = () => {
-  const target = listElement.value
   if (!observer) { return }
-  observer.unobserve(target)
+  observer.disconnect()
+  observer = null
 }
 const shouldRender = computed(() => {
   if (globalStore.disableViewportOptimizations) { return true }

--- a/src/consts.js
+++ b/src/consts.js
@@ -8,7 +8,7 @@ export default {
     min: 20,
     default: 100
   },
-  viewportObserverMaxRootMargin: 50, // percent, shrinks as the space zooms out
+  viewportObserverMaxRootMarginPercent: 50,
   spaceBetweenCards: 12,
   cardCharacterLimit: 4000,
   defaultCardWidth: 58,

--- a/src/consts.js
+++ b/src/consts.js
@@ -8,6 +8,7 @@ export default {
     min: 20,
     default: 100
   },
+  viewportObserverMaxRootMargin: 50, // percent, shrinks as the space zooms out
   spaceBetweenCards: 12,
   cardCharacterLimit: 4000,
   defaultCardWidth: 58,

--- a/src/stores/useGlobalStore.js
+++ b/src/stores/useGlobalStore.js
@@ -353,13 +353,11 @@ export const useGlobalStore = defineStore('global', {
       return 1 / this.getSpaceZoomDecimal
     },
     getViewportObserverRootMargin () {
-      // while pinching, render only what is actually on screen. zooming out fits exponentially
-      // more of the space on screen, so a pre-render margin here renders most of the space
-      // mid gesture and runs ios safari out of memory
+      // while pinching, render only what is actually on screen
       if (this.isPinchZooming) { return '0%' }
-      // otherwise shrink the margin as the space zooms out, for the same reason
+      // otherwise shrink the intersection observer margin as the space zooms out
       const zoom = Math.min(this.getSpaceZoomDecimal, 1)
-      const margin = Math.round(consts.viewportObserverMaxRootMargin * zoom)
+      const margin = Math.round(consts.viewportObserverMaxRootMarginPercent * zoom)
       return `${margin}%`
     },
     getIsTouchDevice () {

--- a/src/stores/useGlobalStore.js
+++ b/src/stores/useGlobalStore.js
@@ -352,6 +352,16 @@ export const useGlobalStore = defineStore('global', {
     getSpaceCounterZoomDecimal () {
       return 1 / this.getSpaceZoomDecimal
     },
+    getViewportObserverRootMargin () {
+      // while pinching, render only what is actually on screen. zooming out fits exponentially
+      // more of the space on screen, so a pre-render margin here renders most of the space
+      // mid gesture and runs ios safari out of memory
+      if (this.isPinchZooming) { return '0%' }
+      // otherwise shrink the margin as the space zooms out, for the same reason
+      const zoom = Math.min(this.getSpaceZoomDecimal, 1)
+      const margin = Math.round(consts.viewportObserverMaxRootMargin * zoom)
+      return `${margin}%`
+    },
     getIsTouchDevice () {
       return this.isTouchDevice || utils.isMobile() || consts.isSecureAppContext
     },
@@ -541,6 +551,7 @@ export const useGlobalStore = defineStore('global', {
     triggerUpdateRemoteDropGuideLine () {},
     triggerUpdateStopRemoteUserDropGuideLine (updates) {},
     triggerUpdateHeaderAndFooterPosition () {},
+    triggerUpdateViewportObservers () {},
     triggerHideTouchInterface () {},
     triggerUpgradeUserIsVisible () {},
     triggerDateAndTimeSettingsIsVisible () {},

--- a/src/views/Space.vue
+++ b/src/views/Space.vue
@@ -334,17 +334,16 @@ const styles = computed(() => {
     transform: globalStore.getZoomTransform
   }
 })
-// item viewport observers use a zoom aware rootMargin, which can only be set when the observer is created.
-// rebuild them once zooming settles instead of on every wheel or pinch tick
+
+// update item intersection observer margin during zoom
+
 const updateViewportObservers = debounce(() => {
-  if (globalStore.isPinchZooming) { return } // already rebuilt at pinch start, restored on pinch end
+  if (globalStore.isPinchZooming) { return }
   globalStore.triggerUpdateViewportObservers()
 }, 300, { maxWait: 1000 })
 watch(() => globalStore.spaceZoomPercent, () => {
   updateViewportObservers()
 })
-// rebuild right away when a pinch starts, so the margin is already collapsed before the space
-// zooms out. debouncing this instead would let the whole space render during the gesture
 watch(() => globalStore.isPinchZooming, (value) => {
   if (value) {
     updateViewportObservers.cancel()

--- a/src/views/Space.vue
+++ b/src/views/Space.vue
@@ -223,6 +223,7 @@ onBeforeUnmount(() => {
   window.removeEventListener('resize', updateViewportSizes)
   clearInterval(processQueueIntervalTimer)
   clearInterval(hourlyTasks)
+  updateViewportObservers.cancel()
   unsubscribes()
 })
 
@@ -331,6 +332,25 @@ const styles = computed(() => {
     width: `${pageWidth.value}px`,
     height: `${pageHeight.value}px`,
     transform: globalStore.getZoomTransform
+  }
+})
+// item viewport observers use a zoom aware rootMargin, which can only be set when the observer is created.
+// rebuild them once zooming settles instead of on every wheel or pinch tick
+const updateViewportObservers = debounce(() => {
+  if (globalStore.isPinchZooming) { return } // already rebuilt at pinch start, restored on pinch end
+  globalStore.triggerUpdateViewportObservers()
+}, 300, { maxWait: 1000 })
+watch(() => globalStore.spaceZoomPercent, () => {
+  updateViewportObservers()
+})
+// rebuild right away when a pinch starts, so the margin is already collapsed before the space
+// zooms out. debouncing this instead would let the whole space render during the gesture
+watch(() => globalStore.isPinchZooming, (value) => {
+  if (value) {
+    updateViewportObservers.cancel()
+    globalStore.triggerUpdateViewportObservers()
+  } else {
+    updateViewportObservers()
   }
 })
 


### PR DESCRIPTION
when zoomed out, margin % covers more area which basically forces way more cards than intended to load