### PR TITLE
perf Off-screen cards stay fully in the DOM

### DIFF
--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -441,6 +441,12 @@ const cardWrapStyle = computed(() => {
     styles.transition = 'all 0.2s ease-out'
   }
   styles = updateStylesWithWidth(styles)
+  if (!shouldRender.value) {
+    const width = resizeWidth.value || props.card.width || consts.emptyCard().width
+    styles.width = `${width}px`
+    styles.maxWidth = `${width}px`
+    styles.height = `${props.card.height || consts.emptyCard().height}px`
+  }
   return styles
 })
 const cardStyle = computed(() => {
@@ -1909,7 +1915,7 @@ const toggleVideoIsPaused = () => {
 )
   .focusing-frame(v-if="isFocusing" :style="{backgroundColor: currentUserColor}" @animationend="clearFocus")
   .card(
-    v-show="shouldRender"
+    v-if="shouldRender"
     @mousedown.left.prevent="startDraggingCard"
     @mouseup.left="showCardDetails"
 

--- a/src/components/KeyboardShortcutsHandler.vue
+++ b/src/components/KeyboardShortcutsHandler.vue
@@ -460,7 +460,7 @@ const handleContextMenuEvents = (event) => {
 }
 
 const scrollIntoView = (card) => {
-  const element = document.querySelector(`.card-wrap [data-card-id="${card.id}"]`)
+  const element = document.querySelector(`.card-wrap[data-card-id="${card.id}"]`)
   globalStore.scrollElementIntoView({ element })
 }
 
@@ -475,9 +475,9 @@ const addCard = async (options) => {
   const canEditSpace = userStore.getUserCanEditSpace
   if (!canEditSpace) { return }
   const parentCardId = globalStore.parentCardId
-  let parentCard = document.querySelector(`.card[data-card-id="${parentCardId}"]`)
+  let parentCard = document.querySelector(`.card-wrap[data-card-id="${parentCardId}"]`)
   const childCardId = globalStore.childCardId
-  let childCard = document.querySelector(`.card[data-card-id="${childCardId}"]`)
+  let childCard = document.querySelector(`.card-wrap[data-card-id="${childCardId}"]`)
   const childCardData = cardStore.getCard(childCardId)
   const shouldOutdentChildToParent = childCard && !childCardData
   const spaceBetweenCards = consts.spaceBetweenCards
@@ -532,8 +532,8 @@ const addChildCard = async (options) => {
 
   const parentCardId = globalStore.parentCardId
   const childCardId = globalStore.childCardId
-  const parentCardElement = document.querySelector(`.card[data-card-id="${parentCardId}"]`)
-  const childCardElement = document.querySelector(`.card[data-card-id="${childCardId}"]`)
+  const parentCardElement = document.querySelector(`.card-wrap[data-card-id="${parentCardId}"]`)
+  const childCardElement = document.querySelector(`.card-wrap[data-card-id="${childCardId}"]`)
   let baseCardElement, baseCardId
   if (childCardElement) {
     baseCardElement = childCardElement
@@ -593,7 +593,7 @@ const addConnection = (baseCardId, position) => {
   } else {
     baseCardId = globalStore.parentCardId
   }
-  const baseCard = document.querySelector(`.card[data-card-id="${baseCardId}"]`)
+  const baseCard = document.querySelector(`.card-wrap[data-card-id="${baseCardId}"]`)
   if (!baseCard) { return }
   const controlPoint = userStore.defaultConnectionControlPoint
   const estimatedEndItemConnectorPosition = utils.estimatedNewCardConnectorPosition(position)

--- a/src/components/dialogs/CardDetails.vue
+++ b/src/components/dialogs/CardDetails.vue
@@ -178,7 +178,7 @@ const closeCardAndFocus = (event) => {
     return
   }
   globalStore.closeAllDialogs()
-  document.querySelector(`.card[data-card-id="${prevCardId}"]`).focus()
+  document.querySelector(`.card[data-card-id="${prevCardId}"]`)?.focus()
 }
 const closeDialogs = (shouldSkipGlobalDialogs) => {
   globalStore.triggerCloseChildDialogs()
@@ -1211,7 +1211,7 @@ const addSplitCards = async (newCards) => {
   // wait for cards to be added to dom
   setTimeout(() => {
     for (const newCard of newCards) {
-      const element = document.querySelector(`.card-wrap [data-card-id="${prevCard.id}"]`)
+      const element = document.querySelector(`.card-wrap[data-card-id="${prevCard.id}"]`)
       const prevCardRect = element.getBoundingClientRect()
       newCard.y = prevCard.y + (prevCardRect.height * globalStore.getSpaceCounterZoomDecimal) + spaceBetweenCards
       cardStore.updateCard(newCard)

--- a/src/components/sidebar/Removed.vue
+++ b/src/components/sidebar/Removed.vue
@@ -179,7 +179,7 @@ const deleteAllCards = () => {
   state.removedCards = []
 }
 const scrollIntoView = (card) => {
-  const element = document.querySelector(`.card-wrap [data-card-id="${card.id}"]`)
+  const element = document.querySelector(`.card-wrap[data-card-id="${card.id}"]`)
   globalStore.scrollElementIntoView({ element })
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1143,14 +1143,20 @@ export default {
   },
   clearAllCardDimensions (card) {
     const cardWrapElement = document.querySelector(`.card-wrap[data-card-id="${card.id}"]`)
+    if (!cardWrapElement) { return }
+    // these only exist while the card is rendered in the viewport
     const cardElement = document.querySelector(`.card[data-card-id="${card.id}"]`)
     const contentWrapElement = cardWrapElement.querySelector('.card-content-wrap')
     const cardMediaElement = cardWrapElement.querySelector('.media-card')
     cardWrapElement.style.width = null
     cardWrapElement.style.height = null
-    cardElement.style.width = null
-    contentWrapElement.style.width = null
-    contentWrapElement.style.height = null
+    if (cardElement) {
+      cardElement.style.width = null
+    }
+    if (contentWrapElement) {
+      contentWrapElement.style.width = null
+      contentWrapElement.style.height = null
+    }
     if (cardMediaElement) {
       cardMediaElement.style.width = null
     }


### PR DESCRIPTION
tradeoff: card child components get removed when offscreen, but remounted when onscreen

verify on device churn diff when scrolling busy space, use search to jump to an off-screen card, and tilt/resize a multi-selection that extends past the viewport