### PR TITLE
item perf: subscribe to specific store actions by name

### DIFF
--- a/src/components/Box.vue
+++ b/src/components/Box.vue
@@ -7,6 +7,7 @@ import { useBoxStore } from '@/stores/useBoxStore'
 import { useUserStore } from '@/stores/useUserStore'
 import { useSpaceStore } from '@/stores/useSpaceStore'
 import { useBroadcastStore } from '@/stores/useBroadcastStore'
+import { useStoreAction } from '@/composables/useStoreAction.js'
 
 import utils from '@/utils.js'
 import consts from '@/consts.js'
@@ -25,8 +26,6 @@ const boxStore = useBoxStore()
 const userStore = useUserStore()
 const spaceStore = useSpaceStore()
 const broadcastStore = useBroadcastStore()
-
-let unsubscribes
 
 const borderWidth = 2
 
@@ -48,26 +47,17 @@ const boxElement = ref(null)
 
 onMounted(() => {
   initViewportObserver()
-
-  const globalActionUnsubscribe = globalStore.$onAction(
-    ({ name, args }) => {
-      if (name === 'updateRemoteCurrentConnection' || name === 'removeRemoteCurrentConnection') {
-        updateRemoteConnections()
-      } else if (name === 'triggerUpdateViewportObservers') {
-        initViewportObserver()
-      }
-    }
-  )
-  unsubscribes = () => {
-    globalActionUnsubscribe()
-  }
 })
 onUpdated(() => {
   initViewportObserver()
 })
 onBeforeUnmount(() => {
   removeViewportObserver()
-  unsubscribes()
+})
+useStoreAction(globalStore, {
+  updateRemoteCurrentConnection: () => updateRemoteConnections(),
+  removeRemoteCurrentConnection: () => updateRemoteConnections(),
+  triggerUpdateViewportObservers: () => initViewportObserver()
 })
 
 const props = defineProps({

--- a/src/components/Card.vue
+++ b/src/components/Card.vue
@@ -15,6 +15,7 @@ import { useBroadcastStore } from '@/stores/useBroadcastStore'
 import { useThemeStore } from '@/stores/useThemeStore'
 
 import { useStickyCard } from '@/composables/useStickyCard.js'
+import { useStoreAction } from '@/composables/useStoreAction.js'
 
 import utils from '@/utils.js'
 import Frames from '@/components/Frames.vue'
@@ -76,8 +77,6 @@ let lockingAnimationTimer, lockingStartTime, shouldCancelLocking
 
 let observer
 
-let unsubscribes
-
 onMounted(async () => {
   updateDefaultBackgroundColor(utils.cssVariable('secondary-background'))
   const shouldFocus = globalStore.loadSpaceFocusOnItemId === props.card.id
@@ -88,43 +87,32 @@ onMounted(async () => {
   updateUrls()
   checkIfShouldUpdateIframeUrl()
   initViewportObserver()
-
-  const globalActionUnsubscribe = globalStore.$onAction(
-    ({ name, args }) => {
-      if (name === 'updateRemoteCurrentConnection' || name === 'removeRemoteCurrentConnection') {
-        updateRemoteConnections()
-      } else if (name === 'triggerScrollItemIntoView') {
-        if (args[0] === props.card.id) {
-          const element = cardElement.value
-          globalStore.scrollElementIntoView({ element, positionIsCenter: true })
-        }
-      } else if (name === 'triggerUploadComplete') {
-        const { cardId, url } = args[0] // cardId, spaceId, url, fileName
-        if (cardId !== props.card.id) { return }
-        addCompletedUpload(args[0])
-      } else if (name === 'triggerUpdateUrlPreview') {
-        if (args[0] === props.card.id) {
-          updateMediaUrls()
-          updateUrlPreview()
-        }
-      } else if (name === 'triggerUpdateTheme') {
-        updateDefaultBackgroundColor(utils.cssVariable('secondary-background'))
-      } else if (name === 'triggerCancelLocking') {
-        cancelLocking()
-      } else if (name === 'triggerIsSnappingToList') {
-        state.isSnappingToList = true
-      } else if (name === 'triggerUpdateViewportObservers') {
-        initViewportObserver()
-      }
-    }
-  )
-  unsubscribes = () => {
-    globalActionUnsubscribe()
-  }
 })
 onBeforeUnmount(() => {
   removeViewportObserver()
-  unsubscribes()
+})
+useStoreAction(globalStore, {
+  updateRemoteCurrentConnection: () => updateRemoteConnections(),
+  removeRemoteCurrentConnection: () => updateRemoteConnections(),
+  triggerScrollItemIntoView: (cardId) => {
+    if (cardId !== props.card.id) { return }
+    const element = cardElement.value
+    globalStore.scrollElementIntoView({ element, positionIsCenter: true })
+  },
+  triggerUploadComplete: (updates) => {
+    const { cardId } = updates // cardId, spaceId, url, fileName
+    if (cardId !== props.card.id) { return }
+    addCompletedUpload(updates)
+  },
+  triggerUpdateUrlPreview: (cardId) => {
+    if (cardId !== props.card.id) { return }
+    updateMediaUrls()
+    updateUrlPreview()
+  },
+  triggerUpdateTheme: () => updateDefaultBackgroundColor(utils.cssVariable('secondary-background')),
+  triggerCancelLocking: () => cancelLocking(),
+  triggerIsSnappingToList: () => { state.isSnappingToList = true },
+  triggerUpdateViewportObservers: () => initViewportObserver()
 })
 
 const props = defineProps({

--- a/src/components/Connection.vue
+++ b/src/components/Connection.vue
@@ -8,6 +8,7 @@ import { useBoxStore } from '@/stores/useBoxStore'
 import { useUserStore } from '@/stores/useUserStore'
 import { useSpaceStore } from '@/stores/useSpaceStore'
 import { useUploadStore } from '@/stores/useUploadStore'
+import { useStoreAction } from '@/composables/useStoreAction.js'
 
 import utils from '@/utils.js'
 
@@ -19,7 +20,6 @@ const userStore = useUserStore()
 const spaceStore = useSpaceStore()
 const uploadStore = useUploadStore()
 
-let unsubscribes
 let animationTimer, isMultiTouch, startCursor, currentCursor
 let observer
 
@@ -30,41 +30,29 @@ const observerTarget = ref(null)
 onMounted(() => {
   initViewportObserver()
   inferConnectionPath()
-  const globalActionUnsubscribe = globalStore.$onAction(
-    ({ name, args }) => {
-      if (name === 'clearMultipleSelected') {
-        const selectedIds = globalStore.multipleConnectionsSelectedIds
-        const selected = selectedIds.includes(props.connection.id) || globalStore.connectionDetailsIsVisibleForConnectionId === props.connection.id
-        if (!selected) {
-          cancelAnimation()
-        }
-      } else if (name === 'triggerConnectionDetailsIsVisible') {
-        const { id, event } = args[0]
-        if (id !== props.connection.id) { return }
-        const isFromStore = true
-        showConnectionDetails(event, isFromStore)
-      } else if (name === 'closeAllDialogs') {
-        updatePathWhileDragging(null)
-      } else if (name === 'triggerUpdateViewportObservers') {
-        initViewportObserver()
-      }
-    }
-  )
-  const cardActionUnsubscribe = cardStore.$onAction(
-    ({ name, args }) => {
-      if (name === 'moveCards') {
-        cancelAnimation()
-      }
-    }
-  )
-  unsubscribes = () => {
-    globalActionUnsubscribe()
-    cardActionUnsubscribe()
-  }
 })
 onBeforeUnmount(() => {
   removeViewportObserver()
-  unsubscribes()
+})
+useStoreAction(globalStore, {
+  clearMultipleSelected: () => {
+    const selectedIds = globalStore.multipleConnectionsSelectedIds
+    const selected = selectedIds.includes(props.connection.id) || globalStore.connectionDetailsIsVisibleForConnectionId === props.connection.id
+    if (!selected) {
+      cancelAnimation()
+    }
+  },
+  triggerConnectionDetailsIsVisible: (options) => {
+    const { id, event } = options
+    if (id !== props.connection.id) { return }
+    const isFromStore = true
+    showConnectionDetails(event, isFromStore)
+  },
+  closeAllDialogs: () => updatePathWhileDragging(null),
+  triggerUpdateViewportObservers: () => initViewportObserver()
+})
+useStoreAction(cardStore, {
+  moveCards: () => cancelAnimation()
 })
 
 const props = defineProps({

--- a/src/components/ImageOrVideo.vue
+++ b/src/components/ImageOrVideo.vue
@@ -2,6 +2,7 @@
 import { reactive, computed, onMounted, onBeforeUnmount, watch, ref, nextTick } from 'vue'
 
 import { useGlobalStore } from '@/stores/useGlobalStore'
+import { useStoreAction } from '@/composables/useStoreAction.js'
 
 import utils from '@/utils.js'
 import consts from '@/consts.js'
@@ -11,7 +12,6 @@ const globalStore = useGlobalStore()
 const videoElement = ref(null)
 const imageElement = ref(null)
 
-let unsubscribes
 let pausedCanvas
 
 onMounted(() => {
@@ -21,20 +21,13 @@ onMounted(() => {
   window.addEventListener('focus', updateIsPlaying)
   window.addEventListener('blur', updateIsPlaying)
   document.addEventListener('visibilitychange', updateIsPlaying)
-
-  const globalActionUnsubscribe = globalStore.$onAction(
-    async ({ name, args }) => {
-      if (name === 'triggerUploadComplete') {
-        const { url, fileName } = args[0]
-        if (props.video.includes(fileName)) {
-          await nextTick()
-          videoElement.value.load()
-        }
-      }
-    }
-  )
-  unsubscribes = () => {
-    globalActionUnsubscribe()
+})
+useStoreAction(globalStore, {
+  triggerUploadComplete: async (updates) => {
+    const { fileName } = updates
+    if (!props.video.includes(fileName)) { return }
+    await nextTick()
+    videoElement.value.load()
   }
 })
 onBeforeUnmount(() => {
@@ -45,7 +38,6 @@ onBeforeUnmount(() => {
   document.removeEventListener('visibilitychange', updateIsPlaying)
   pausedCanvas?.remove()
   pausedCanvas = null
-  unsubscribes()
 })
 
 const emit = defineEmits(['loadSuccess'])

--- a/src/components/ItemConnectorButton.vue
+++ b/src/components/ItemConnectorButton.vue
@@ -1,11 +1,12 @@
 <script setup>
-import { reactive, computed, onMounted, onBeforeUnmount, watch, ref, nextTick } from 'vue'
+import { reactive, computed, watch, ref, nextTick } from 'vue'
 
 import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useUserStore } from '@/stores/useUserStore'
 import { useSpaceStore } from '@/stores/useSpaceStore'
 import { useGlobalStore } from '@/stores/useGlobalStore'
 import { useThemeStore } from '@/stores/useThemeStore'
+import { useStoreAction } from '@/composables/useStoreAction.js'
 
 import utils from '@/utils.js'
 import last from 'lodash-es/last'
@@ -16,24 +17,9 @@ const userStore = useUserStore()
 const spaceStore = useSpaceStore()
 const themeStore = useThemeStore()
 
-let unsubscribes
-
-onMounted(() => {
-  const globalActionUnsubscribe = globalStore.$onAction(
-    ({ name, args }) => {
-      if (name === 'triggerUpdateCurrentConnectorColor') {
-        updateCurrentConnectorColor()
-      } else if (name === 'triggerClearCurrentConnectorColor') {
-        clearCurrentConnectorColor()
-      }
-    }
-  )
-  unsubscribes = () => {
-    globalActionUnsubscribe()
-  }
-})
-onBeforeUnmount(() => {
-  unsubscribes()
+useStoreAction(globalStore, {
+  triggerUpdateCurrentConnectorColor: () => updateCurrentConnectorColor(),
+  triggerClearCurrentConnectorColor: () => clearCurrentConnectorColor()
 })
 
 const emit = defineEmits(['shouldRenderParent'])

--- a/src/components/ItemSnapGuide.vue
+++ b/src/components/ItemSnapGuide.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { reactive, computed, onMounted, onBeforeUnmount, watch, ref, nextTick } from 'vue'
+import { reactive, computed, onMounted, watch, ref, nextTick } from 'vue'
 
 import { useGlobalStore } from '@/stores/useGlobalStore'
 import { useBoxStore } from '@/stores/useBoxStore'
@@ -7,6 +7,7 @@ import { useCardStore } from '@/stores/useCardStore'
 import { useListStore } from '@/stores/useListStore'
 import { useUserStore } from '@/stores/useUserStore'
 import { useSpaceStore } from '@/stores/useSpaceStore'
+import { useStoreAction } from '@/composables/useStoreAction.js'
 
 import utils from '@/utils.js'
 import consts from '@/consts.js'
@@ -18,26 +19,13 @@ const listStore = useListStore()
 const userStore = useUserStore()
 const spaceStore = useSpaceStore()
 
-let unsubscribes
-
 let waitingAnimationTimer, shouldCancelWaiting, waitingStartTime
 
 onMounted(() => {
   updateRect()
-
-  const globalActionUnsubscribe = globalStore.$onAction(
-    ({ name, args }) => {
-      if (name === 'clearDraggingItems') {
-        cancelWaitingAnimationFrame()
-      }
-    }
-  )
-  unsubscribes = () => {
-    globalActionUnsubscribe()
-  }
 })
-onBeforeUnmount(() => {
-  unsubscribes()
+useStoreAction(globalStore, {
+  clearDraggingItems: () => cancelWaitingAnimationFrame()
 })
 
 const props = defineProps({

--- a/src/components/List.vue
+++ b/src/components/List.vue
@@ -8,6 +8,7 @@ import { useConnectionStore } from '@/stores/useConnectionStore'
 import { useUserStore } from '@/stores/useUserStore'
 import { useSpaceStore } from '@/stores/useSpaceStore'
 import { useBroadcastStore } from '@/stores/useBroadcastStore'
+import { useStoreAction } from '@/composables/useStoreAction.js'
 
 import Frames from '@/components/Frames.vue'
 import utils from '@/utils.js'
@@ -23,8 +24,6 @@ const connectionStore = useConnectionStore()
 const userStore = useUserStore()
 const spaceStore = useSpaceStore()
 const broadcastStore = useBroadcastStore()
-
-let unsubscribes
 
 // locking
 // long press to touch drag
@@ -42,26 +41,16 @@ const listElement = ref(null)
 
 onMounted(() => {
   initViewportObserver()
-
-  const globalActionUnsubscribe = globalStore.$onAction(
-    ({ name, args }) => {
-      if (name === 'clearDraggingItems') {
-        state.isDraggingCardOverList = false
-      } else if (name === 'triggerUpdateViewportObservers') {
-        initViewportObserver()
-      }
-    }
-  )
-  unsubscribes = () => {
-    globalActionUnsubscribe()
-  }
 })
 onUpdated(() => {
   initViewportObserver()
 })
 onBeforeUnmount(() => {
   removeViewportObserver()
-  unsubscribes()
+})
+useStoreAction(globalStore, {
+  clearDraggingItems: () => { state.isDraggingCardOverList = false },
+  triggerUpdateViewportObservers: () => initViewportObserver()
 })
 
 const props = defineProps({

--- a/src/components/Panning.vue
+++ b/src/components/Panning.vue
@@ -60,8 +60,8 @@ onBeforeUnmount(() => {
 const checkIfShouldStartPanning = (event) => {
   if (globalStore.currentUserIsPanning) {
     event.preventDefault()
-    updatePanningPosition(event)
     initPanning(event)
+    updatePanningPosition(event)
   }
 }
 const checkIfShouldStartMomentum = () => {
@@ -69,6 +69,8 @@ const checkIfShouldStartMomentum = () => {
   if (isPanning && panningDelta) {
     startMomentum()
   }
+  // clear the pending pan frame alongside its delta, momentum continues from velocity
+  shouldPanNextFrame = false
   panningDelta = null
   shouldCancelPanningTimer = true
 }
@@ -122,10 +124,15 @@ const updatePanningPosition = (event) => {
 }
 const panningFrame = () => {
   // scroll frame
-  if (shouldPanNextFrame) {
+  if (shouldPanNextFrame && panningDelta) {
     window.scrollBy(panningDelta.x, panningDelta.y, 'instant')
     updatecurrentScrollByDelta(panningDelta)
     shouldPanNextFrame = false
+  } else if (velocity) {
+    // no cursor movement this frame, decay velocity so that pausing
+    // before releasing doesn't fling on momentum from an older movement
+    velocity.x *= momentumDeceleration
+    velocity.y *= momentumDeceleration
   }
   panningTimer = window.requestAnimationFrame(panningFrame)
   // cancel
@@ -139,6 +146,7 @@ const panningFrame = () => {
 // momentum scrolling, post-panning
 
 const startMomentum = () => {
+  window.cancelAnimationFrame(momentumTimer)
   const momentumFrame = () => {
     // cancel
     const velocityIsLow = Math.abs(velocity.x) < momentumThreshold && Math.abs(velocity.y) < momentumThreshold

--- a/src/composables/useStoreAction.js
+++ b/src/composables/useStoreAction.js
@@ -1,0 +1,43 @@
+// subscribe to specific store actions by name (item perf)
+
+import { onBeforeUnmount } from 'vue'
+
+const registries = new WeakMap() // store → Map of action name → Set of callbacks
+
+const listenersForStore = (store) => {
+  let listeners = registries.get(store)
+  if (listeners) { return listeners }
+  listeners = new Map()
+  registries.set(store, listeners)
+  // detached, else the subscription is disposed with whichever component happened to create it
+  store.$onAction(({ name, args }) => {
+    const callbacks = listeners.get(name)
+    if (!callbacks) { return }
+    // copy, because a callback can unmount a component and remove listeners while dispatching
+    Array.from(callbacks).forEach(callback => callback(args[0]))
+  }, true)
+  return listeners
+}
+
+export const useStoreAction = (store, handlers) => {
+  const listeners = listenersForStore(store)
+  const entries = Object.entries(handlers)
+  entries.forEach(([name, callback]) => {
+    let callbacks = listeners.get(name)
+    if (!callbacks) {
+      callbacks = new Set()
+      listeners.set(name, callbacks)
+    }
+    callbacks.add(callback)
+  })
+  onBeforeUnmount(() => {
+    entries.forEach(([name, callback]) => {
+      const callbacks = listeners.get(name)
+      if (!callbacks) { return }
+      callbacks.delete(callback)
+      if (!callbacks.size) {
+        listeners.delete(name)
+      }
+    })
+  })
+}


### PR DESCRIPTION
// pinia notifies every $onAction subscriber for every action on a store, and copies the whole // subscriber array on each dispatch. items each subscribe to one store, so a busy space runs // thousands of callbacks per action, including hot ones like zoomSpaceTo that no item cares about. // items share a single subscription per store here, and are dispatched by action name instead